### PR TITLE
Skip and group features to reduce powerset size

### DIFF
--- a/.github/workflows/feature_powerset.yml
+++ b/.github/workflows/feature_powerset.yml
@@ -52,7 +52,11 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       - name: Test
         run: cargo hack test --no-fail-fast --feature-powerset --skip default --group-features jwt-ietf,jwt --group-features jwt-openid,jwt --clean-per-run --log-group github-actions --exclude-no-default-features --exclude-all-features
+      - name: Clean
+        run: cargo clean
       - name: Check
         run: cargo hack check --feature-powerset --no-dev-deps --skip default --group-features jwt-ietf,jwt --group-features jwt-openid,jwt --clean-per-run --log-group github-actions --exclude-no-default-features --exclude-all-features
+      - name: Clean
+        run: cargo clean
       - name: Clippy
         run: cargo hack clippy --all-targets --feature-powerset --skip default --group-features jwt-ietf,jwt --group-features jwt-openid,jwt --clean-per-run --log-group github-actions --exclude-no-default-features --exclude-all-features -- -D warnings


### PR DESCRIPTION
We run out of space on the default github action runners when we naively run `cargo hack` powerset. Attempt to reduce the size of the powerset by skipping the default feature, and grouping related features together.