### PR TITLE
Use a separate redis connection pool for enqueuing vs fetching jobs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ sea-orm-migration = { version = "1.0.0-rc.2", features = ["runtime-tokio-rustls"
 
 # Workers
 # Todo: the default `rss-stats` feature has a dependency that currently can't be satisfied (memchr: ~2.3)
-rusty-sidekiq = { version = "0.10.3", default-features = false, optional = true }
+rusty-sidekiq = { version = "0.10.4", default-features = false, optional = true }
 bb8 = { version = "0.8.3", optional = true }
 num_cpus = { version = "1.16.0", optional = true }
 

--- a/src/app_context.rs
+++ b/src/app_context.rs
@@ -14,7 +14,9 @@ pub struct AppContext {
     #[cfg(feature = "db-sql")]
     pub db: DatabaseConnection,
     #[cfg(feature = "sidekiq")]
-    pub redis: sidekiq::RedisPool,
+    pub redis_enqueue: sidekiq::RedisPool,
+    #[cfg(feature = "sidekiq")]
+    pub redis_fetch: sidekiq::RedisPool,
     #[cfg(feature = "open-api")]
     pub api: Arc<OpenApi>,
     // Prevent consumers from directly creating an AppContext
@@ -25,7 +27,8 @@ impl AppContext {
     pub async fn new(
         config: AppConfig,
         #[cfg(feature = "db-sql")] db: DatabaseConnection,
-        #[cfg(feature = "sidekiq")] redis: sidekiq::RedisPool,
+        #[cfg(feature = "sidekiq")] redis_enqueue: sidekiq::RedisPool,
+        #[cfg(feature = "sidekiq")] redis_fetch: sidekiq::RedisPool,
         #[cfg(feature = "open-api")] api: Arc<OpenApi>,
     ) -> anyhow::Result<Self> {
         let context = Self {
@@ -33,7 +36,9 @@ impl AppContext {
             #[cfg(feature = "db-sql")]
             db,
             #[cfg(feature = "sidekiq")]
-            redis,
+            redis_enqueue,
+            #[cfg(feature = "sidekiq")]
+            redis_fetch,
             #[cfg(feature = "open-api")]
             api,
             _private: (),

--- a/src/config/worker.rs
+++ b/src/config/worker.rs
@@ -3,16 +3,13 @@ use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumString, IntoStaticStr};
 use url::Url;
 
-#[cfg(feature = "sidekiq")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Worker {
     // Todo: Make Redis optional for workers?
-    #[cfg(feature = "sidekiq")]
     pub sidekiq: Sidekiq,
 }
 
-#[cfg(feature = "sidekiq")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Sidekiq {
@@ -50,7 +47,6 @@ impl Sidekiq {
     }
 }
 
-#[cfg(feature = "sidekiq")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Periodic {
@@ -74,18 +70,22 @@ pub enum StaleCleanUpBehavior {
     AutoCleanStale,
 }
 
-#[cfg(feature = "sidekiq")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Redis {
     pub uri: Url,
+    /// The configuration for the Redis connection pool used for enqueuing Sidekiq jobs in Redis.
     #[serde(default)]
+    pub enqueue_pool: ConnectionPool,
+    /// The configuration for the Redis connection pool used by [sidekiq::Processor] to fetch
+    /// Sidekiq jobs from Redis.
+    #[serde(default)]
+    pub fetch_pool: ConnectionPool,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct ConnectionPool {
     pub min_idle: Option<u32>,
-    /// The maximum number of Redis connections to allow. If not specified, will default to
-    /// [worker.sidekiq.num-workers][crate::config::worker::Sidekiq], plus a small amount to
-    /// allow other things to access Redis as needed, for example, a health check endpoint.
-    // Todo: Is it okay if this is equal to or smaller than the number of workers, or does each
-    //  worker task consume a connection?
-    #[serde(default)]
     pub max_connections: Option<u32>,
 }

--- a/src/worker/app_worker.rs
+++ b/src/worker/app_worker.rs
@@ -59,7 +59,7 @@ where
     /// [sidekiq::RedisPool] from inside the [state][App::State].
     async fn enqueue(state: &A::State, args: Args) -> anyhow::Result<()> {
         let context: Arc<AppContext> = state.clone().into();
-        Self::perform_async(&context.redis, args).await?;
+        Self::perform_async(&context.redis_enqueue, args).await?;
         Ok(())
     }
 

--- a/src/worker/registry.rs
+++ b/src/worker/registry.rs
@@ -94,7 +94,7 @@ where
         &self,
         context: &AppContext,
     ) -> anyhow::Result<()> {
-        let mut conn = context.redis.get().await?;
+        let mut conn = context.redis_enqueue.get().await?;
         let stale_jobs = conn
             .zrange(PERIODIC_KEY.to_string(), 0, -1)
             .await?


### PR DESCRIPTION
Problem
-------
If the job queue is empty, sidekiq.rs will wait a couple seconds before releasing its connection. This can delay adding items to the queue by up to a couple seconds depending on how the timing works out, which is bad because adding the the queue should be as fast as possible.

Solution
--------
Use separate connection pools for enqueuing vs fetching jobs from the queue. This decouples enqueuing from needing to wait for a connection that is being blocked by a worker task that's waiting for a job to be added to the queue in the `sidekiq::Processor`.