### PR TITLE
Don't run Processor depending on configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Docs
         env:
           RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private_intra_doc_links"
-        run: cargo doc --all-features --no-deps
+        run: cargo doc --all-features

--- a/src/app_context.rs
+++ b/src/app_context.rs
@@ -15,8 +15,11 @@ pub struct AppContext {
     pub db: DatabaseConnection,
     #[cfg(feature = "sidekiq")]
     pub redis_enqueue: sidekiq::RedisPool,
+    /// The Redis connection pool used by [sidekiq::Processor] to fetch Sidekiq jobs from Redis.
+    /// May be `None` if the [fetch_pool.max_connections][crate::config::worker::ConnectionPool]
+    /// config is set to zero, in which case the [sidekiq::Processor] would also not be started.
     #[cfg(feature = "sidekiq")]
-    pub redis_fetch: sidekiq::RedisPool,
+    pub redis_fetch: Option<sidekiq::RedisPool>,
     #[cfg(feature = "open-api")]
     pub api: Arc<OpenApi>,
     // Prevent consumers from directly creating an AppContext
@@ -28,7 +31,7 @@ impl AppContext {
         config: AppConfig,
         #[cfg(feature = "db-sql")] db: DatabaseConnection,
         #[cfg(feature = "sidekiq")] redis_enqueue: sidekiq::RedisPool,
-        #[cfg(feature = "sidekiq")] redis_fetch: sidekiq::RedisPool,
+        #[cfg(feature = "sidekiq")] redis_fetch: Option<sidekiq::RedisPool>,
         #[cfg(feature = "open-api")] api: Arc<OpenApi>,
     ) -> anyhow::Result<Self> {
         let context = Self {

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -6,8 +6,6 @@ use crate::app::App;
 use crate::worker::app_worker::AppWorkerConfig;
 use app_worker::AppWorker;
 use async_trait::async_trait;
-use itertools::Itertools;
-use lazy_static::lazy_static;
 use serde::Serialize;
 
 use sidekiq::{RedisPool, Worker, WorkerOpts};
@@ -15,24 +13,6 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, instrument};
-
-lazy_static! {
-    // Todo: We don't need to specifically provide the `default` queue. However, if no queues
-    //  are provided, Sidekiq.rs will error out. If no queues are provided, we should probably
-    //  just not initialize the Sidekiq.rs processor instead of providing a `default` queue,
-    //  which may not be what the consumer wants.
-    pub static ref DEFAULT_QUEUE_NAMES: Vec<String> =
-        ["default"].iter().map(|s| s.to_string()).collect();
-}
-
-pub fn queues(custom_queue_names: &Vec<String>) -> Vec<String> {
-    DEFAULT_QUEUE_NAMES
-        .iter()
-        .chain(custom_queue_names)
-        .unique()
-        .map(|s| s.to_owned())
-        .collect()
-}
 
 /// Worker used by Roadster to wrap the consuming app's workers to add additional behavior. For
 /// example, [RoadsterWorker] is by default configured to automatically abort the app's worker


### PR DESCRIPTION
Don't run the `sidekiq::Processor` if:
- The app has configured a max connection pool size of zero for the fetch pool
- The app does not have any sidekiq queues configured

https://github.com/roadster-rs/roadster/issues/55