### PR TITLE
Add `AppService` trait and use it to implement the HTTP service

### DIFF
--- a/examples/minimal/config/default.toml
+++ b/examples/minimal/config/default.toml
@@ -1,7 +1,8 @@
 [app]
 name = "Minimal Example"
 
-[server]
+[service.http]
+enable = true
 host = "127.0.0.1"
 port = 3000
 

--- a/examples/minimal/src/app.rs
+++ b/examples/minimal/src/app.rs
@@ -2,11 +2,10 @@ use async_trait::async_trait;
 use migration::Migrator;
 use roadster::app::App as RoadsterApp;
 use roadster::app_context::AppContext;
-use roadster::service::http::http_service_builder::HttpServiceBuilder;
-use roadster::service::AppService;
+use roadster::service::http::http_service::HttpService;
+use roadster::service::registry::ServiceRegistry;
 use roadster::worker::app_worker::AppWorker;
 use roadster::worker::registry::WorkerRegistry;
-use std::vec;
 
 use crate::app_state::AppState;
 use crate::cli::AppCli;
@@ -34,15 +33,14 @@ impl RoadsterApp for App {
     }
 
     async fn services(
+        registry: &mut ServiceRegistry<Self>,
         context: &AppContext,
-        state: &Self::State,
-    ) -> anyhow::Result<Vec<Box<dyn AppService<Self>>>> {
-        let http_service = Box::new(
-            HttpServiceBuilder::<Self>::new(BASE, context)
-                .router(controller::routes(BASE))
-                .build(context, state)?,
-        );
+        _state: &Self::State,
+    ) -> anyhow::Result<()> {
+        registry.register_builder(
+            HttpService::builder(BASE, context).router(controller::routes(BASE)),
+        )?;
 
-        Ok(vec![http_service])
+        Ok(())
     }
 }

--- a/src/app_context.rs
+++ b/src/app_context.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-#[cfg(feature = "open-api")]
-use aide::openapi::OpenApi;
 #[cfg(feature = "db-sql")]
 use sea_orm::DatabaseConnection;
 
@@ -20,8 +18,6 @@ pub struct AppContext {
     /// config is set to zero, in which case the [sidekiq::Processor] would also not be started.
     #[cfg(feature = "sidekiq")]
     pub redis_fetch: Option<sidekiq::RedisPool>,
-    #[cfg(feature = "open-api")]
-    pub api: Arc<OpenApi>,
     // Prevent consumers from directly creating an AppContext
     _private: (),
 }
@@ -32,7 +28,6 @@ impl AppContext {
         #[cfg(feature = "db-sql")] db: DatabaseConnection,
         #[cfg(feature = "sidekiq")] redis_enqueue: sidekiq::RedisPool,
         #[cfg(feature = "sidekiq")] redis_fetch: Option<sidekiq::RedisPool>,
-        #[cfg(feature = "open-api")] api: Arc<OpenApi>,
     ) -> anyhow::Result<Self> {
         let context = Self {
             config,
@@ -42,8 +37,6 @@ impl AppContext {
             redis_enqueue,
             #[cfg(feature = "sidekiq")]
             redis_fetch,
-            #[cfg(feature = "open-api")]
-            api,
             _private: (),
         };
         Ok(context)

--- a/src/cli/list_routes.rs
+++ b/src/cli/list_routes.rs
@@ -1,31 +1,4 @@
-use async_trait::async_trait;
 use clap::Parser;
-use tracing::info;
-
-use crate::app::App;
-use crate::app_context::AppContext;
-use crate::cli::{RoadsterCli, RunRoadsterCommand};
 
 #[derive(Debug, Parser)]
 pub struct ListRoutesArgs {}
-
-#[async_trait]
-impl<A> RunRoadsterCommand<A> for ListRoutesArgs
-where
-    A: App,
-{
-    async fn run(
-        &self,
-        _app: &A,
-        _cli: &RoadsterCli,
-        context: &AppContext,
-    ) -> anyhow::Result<bool> {
-        info!("API routes:");
-        context
-            .api
-            .as_ref()
-            .operations()
-            .for_each(|(path, method, _operation)| info!("[{method}]\t{path}"));
-        Ok(true)
-    }
-}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -154,9 +154,17 @@ where
     async fn run(&self, app: &A, cli: &RoadsterCli, context: &AppContext) -> anyhow::Result<bool> {
         match self {
             #[cfg(feature = "open-api")]
-            RoadsterSubCommand::ListRoutes(args) => args.run(app, cli, context).await,
+            RoadsterSubCommand::ListRoutes(_) => {
+                #[allow(unused_doc_comments)]
+                /// Implemented by [crate::service::http::http_service::HttpService]
+                Ok(false)
+            }
             #[cfg(feature = "open-api")]
-            RoadsterSubCommand::OpenApi(args) => args.run(app, cli, context).await,
+            RoadsterSubCommand::OpenApi(_) => {
+                #[allow(unused_doc_comments)]
+                /// Implemented by [crate::service::http::http_service::HttpService]
+                Ok(false)
+            }
             #[cfg(feature = "db-sql")]
             RoadsterSubCommand::Migrate(args) => args.run(app, cli, context).await,
             RoadsterSubCommand::PrintConfig(args) => args.run(app, cli, context).await,

--- a/src/cli/open_api_schema.rs
+++ b/src/cli/open_api_schema.rs
@@ -1,14 +1,5 @@
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
-use async_trait::async_trait;
 use clap::Parser;
-use tracing::info;
-
-use crate::app::App;
-use crate::app_context::AppContext;
-use crate::cli::{RoadsterCli, RunRoadsterCommand};
+use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 pub struct OpenApiArgs {
@@ -18,32 +9,4 @@ pub struct OpenApiArgs {
     /// Whether to pretty-print the schema. Default: false.
     #[clap(short, long, default_value_t = false)]
     pub pretty_print: bool,
-}
-
-#[async_trait]
-impl<A> RunRoadsterCommand<A> for OpenApiArgs
-where
-    A: App,
-{
-    async fn run(
-        &self,
-        _app: &A,
-        _cli: &RoadsterCli,
-        context: &AppContext,
-    ) -> anyhow::Result<bool> {
-        let schema_json = if self.pretty_print {
-            serde_json::to_string_pretty(context.api.as_ref())?
-        } else {
-            serde_json::to_string(context.api.as_ref())?
-        };
-        if let Some(path) = &self.output {
-            info!("Writing schema to {:?}", path);
-            write!(File::create(path)?, "{schema_json}")?;
-        } else {
-            info!("OpenAPI schema:");
-            info!("{schema_json}");
-        };
-
-        Ok(true)
-    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,6 +1,5 @@
 pub mod app_config;
 pub mod environment;
-pub mod initializer;
-pub mod middleware;
+pub mod service;
 #[cfg(feature = "sidekiq")]
 pub mod worker;

--- a/src/config/service/http_service/mod.rs
+++ b/src/config/service/http_service/mod.rs
@@ -1,0 +1,30 @@
+use crate::config::service::http_service::initializer::Initializer;
+use crate::config::service::http_service::middleware::Middleware;
+use serde_derive::{Deserialize, Serialize};
+
+pub mod initializer;
+pub mod middleware;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct HttpServiceConfig {
+    #[serde(flatten)]
+    pub address: Address,
+    #[serde(default)]
+    pub middleware: Middleware,
+    #[serde(default)]
+    pub initializer: Initializer,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Address {
+    pub host: String,
+    pub port: u32,
+}
+
+impl Address {
+    pub fn url(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}

--- a/src/config/service/mod.rs
+++ b/src/config/service/mod.rs
@@ -1,0 +1,39 @@
+pub mod http_service;
+
+use crate::app_context::AppContext;
+use crate::config::service::http_service::HttpServiceConfig;
+use crate::util::serde_util::default_true;
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Service {
+    #[serde(default = "default_true")]
+    pub default_enable: bool,
+    pub http: ServiceConfig<HttpServiceConfig>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct CommonConfig {
+    // Optional so we can tell the difference between a consumer explicitly enabling/disabling
+    // the service, vs the service being enabled/disabled by default.
+    // If this is `None`, the value will match the value of `Middleware#default_enable`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable: Option<bool>,
+}
+
+impl CommonConfig {
+    pub fn enabled(&self, context: &AppContext) -> bool {
+        self.enable.unwrap_or(context.config.service.default_enable)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ServiceConfig<T> {
+    #[serde(flatten, default)]
+    pub common: CommonConfig,
+    #[serde(flatten)]
+    pub custom: T,
+}

--- a/src/controller/middleware/catch_panic.rs
+++ b/src/controller/middleware/catch_panic.rs
@@ -17,6 +17,9 @@ impl<S> Middleware<S> for CatchPanicMiddleware {
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .catch_panic
             .common
@@ -24,7 +27,15 @@ impl<S> Middleware<S> for CatchPanicMiddleware {
     }
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
-        context.config.middleware.catch_panic.common.priority
+        context
+            .config
+            .service
+            .http
+            .custom
+            .middleware
+            .catch_panic
+            .common
+            .priority
     }
 
     fn install(&self, router: Router, _context: &AppContext, _state: &S) -> anyhow::Result<Router> {

--- a/src/controller/middleware/compression.rs
+++ b/src/controller/middleware/compression.rs
@@ -23,6 +23,9 @@ impl<S> Middleware<S> for ResponseCompressionMiddleware {
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .response_compression
             .common
@@ -32,6 +35,9 @@ impl<S> Middleware<S> for ResponseCompressionMiddleware {
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .response_compression
             .common
@@ -54,6 +60,9 @@ impl<S> Middleware<S> for RequestDecompressionMiddleware {
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .request_decompression
             .common
@@ -63,6 +72,9 @@ impl<S> Middleware<S> for RequestDecompressionMiddleware {
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .request_decompression
             .common

--- a/src/controller/middleware/request_id.rs
+++ b/src/controller/middleware/request_id.rs
@@ -45,6 +45,9 @@ impl<S> Middleware<S> for SetRequestIdMiddleware {
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .set_request_id
             .common
@@ -52,12 +55,23 @@ impl<S> Middleware<S> for SetRequestIdMiddleware {
     }
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
-        context.config.middleware.set_request_id.common.priority
+        context
+            .config
+            .service
+            .http
+            .custom
+            .middleware
+            .set_request_id
+            .common
+            .priority
     }
 
     fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
         let header_name = &context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .set_request_id
             .custom
@@ -82,6 +96,9 @@ impl<S> Middleware<S> for PropagateRequestIdMiddleware {
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .propagate_request_id
             .common
@@ -91,6 +108,9 @@ impl<S> Middleware<S> for PropagateRequestIdMiddleware {
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .propagate_request_id
             .common
@@ -100,6 +120,9 @@ impl<S> Middleware<S> for PropagateRequestIdMiddleware {
     fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
         let header_name = &context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .propagate_request_id
             .custom

--- a/src/controller/middleware/sensitive_headers.rs
+++ b/src/controller/middleware/sensitive_headers.rs
@@ -64,6 +64,9 @@ impl<S> Middleware<S> for SensitiveRequestHeadersMiddleware {
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .sensitive_request_headers
             .common
@@ -73,6 +76,9 @@ impl<S> Middleware<S> for SensitiveRequestHeadersMiddleware {
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .sensitive_request_headers
             .common
@@ -81,6 +87,9 @@ impl<S> Middleware<S> for SensitiveRequestHeadersMiddleware {
     fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
         let headers = context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .sensitive_request_headers
             .custom
@@ -103,6 +112,9 @@ impl<S> Middleware<S> for SensitiveResponseHeadersMiddleware {
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .sensitive_response_headers
             .common
@@ -112,6 +124,9 @@ impl<S> Middleware<S> for SensitiveResponseHeadersMiddleware {
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .sensitive_response_headers
             .common
@@ -120,6 +135,9 @@ impl<S> Middleware<S> for SensitiveResponseHeadersMiddleware {
     fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
         let headers = context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .sensitive_response_headers
             .custom

--- a/src/controller/middleware/size_limit.rs
+++ b/src/controller/middleware/size_limit.rs
@@ -29,16 +29,35 @@ impl<S> Middleware<S> for RequestBodyLimitMiddleware {
     }
 
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
-        context.config.middleware.size_limit.common.enabled(context)
+        context
+            .config
+            .service
+            .http
+            .custom
+            .middleware
+            .size_limit
+            .common
+            .enabled(context)
     }
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
-        context.config.middleware.size_limit.common.priority
+        context
+            .config
+            .service
+            .http
+            .custom
+            .middleware
+            .size_limit
+            .common
+            .priority
     }
 
     fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
         let limit = &context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .size_limit
             .custom

--- a/src/controller/middleware/timeout.rs
+++ b/src/controller/middleware/timeout.rs
@@ -29,15 +29,39 @@ impl<S> Middleware<S> for TimeoutMiddleware {
     }
 
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
-        context.config.middleware.timeout.common.enabled(context)
+        context
+            .config
+            .service
+            .http
+            .custom
+            .middleware
+            .timeout
+            .common
+            .enabled(context)
     }
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
-        context.config.middleware.timeout.common.priority
+        context
+            .config
+            .service
+            .http
+            .custom
+            .middleware
+            .timeout
+            .common
+            .priority
     }
 
     fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
-        let timeout = &context.config.middleware.timeout.custom.timeout;
+        let timeout = &context
+            .config
+            .service
+            .http
+            .custom
+            .middleware
+            .timeout
+            .custom
+            .timeout;
 
         let router = router.layer(TimeoutLayer::new(*timeout));
 

--- a/src/controller/middleware/tracing.rs
+++ b/src/controller/middleware/tracing.rs
@@ -22,16 +22,35 @@ impl<S> Middleware<S> for TracingMiddleware {
     }
 
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
-        context.config.middleware.tracing.common.enabled(context)
+        context
+            .config
+            .service
+            .http
+            .custom
+            .middleware
+            .tracing
+            .common
+            .enabled(context)
     }
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
-        context.config.middleware.tracing.common.priority
+        context
+            .config
+            .service
+            .http
+            .custom
+            .middleware
+            .tracing
+            .common
+            .priority
     }
 
     fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
         let request_id_header_name = &context
             .config
+            .service
+            .http
+            .custom
             .middleware
             .set_request_id
             .custom

--- a/src/initializer/normalize_path.rs
+++ b/src/initializer/normalize_path.rs
@@ -19,6 +19,9 @@ impl<S> Initializer<S> for NormalizePathInitializer {
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
             .config
+            .service
+            .http
+            .custom
             .initializer
             .normalize_path
             .common
@@ -26,7 +29,15 @@ impl<S> Initializer<S> for NormalizePathInitializer {
     }
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
-        context.config.initializer.normalize_path.common.priority
+        context
+            .config
+            .service
+            .http
+            .custom
+            .initializer
+            .normalize_path
+            .common
+            .priority
     }
 
     fn before_serve(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod cli;
 pub mod config;
 pub mod controller;
 pub mod initializer;
+pub mod service;
 pub mod tracing;
 pub mod util;
 pub mod view;

--- a/src/service/http/http_service_builder.rs
+++ b/src/service/http/http_service_builder.rs
@@ -1,0 +1,147 @@
+use crate::app::App;
+use crate::app_context::AppContext;
+use crate::controller::default_routes;
+use crate::controller::middleware::default::default_middleware;
+use crate::controller::middleware::Middleware;
+use crate::initializer::default::default_initializers;
+use crate::initializer::Initializer;
+use crate::service::http::http_service::HttpService;
+#[cfg(feature = "open-api")]
+use aide::axum::ApiRouter;
+#[cfg(feature = "open-api")]
+use aide::openapi::OpenApi;
+#[cfg(feature = "open-api")]
+use aide::transform::TransformOpenApi;
+#[cfg(feature = "open-api")]
+use axum::Extension;
+#[cfg(not(feature = "open-api"))]
+use axum::Router;
+use itertools::Itertools;
+#[cfg(feature = "open-api")]
+use std::sync::Arc;
+use tracing::info;
+
+pub struct HttpServiceBuilder<A: App> {
+    #[cfg(not(feature = "open-api"))]
+    router: Router<A::State>,
+    #[cfg(feature = "open-api")]
+    router: ApiRouter<A::State>,
+    #[cfg(feature = "open-api")]
+    api_docs: Box<dyn Fn(TransformOpenApi) -> TransformOpenApi>,
+    middleware: Vec<Box<dyn Middleware<A::State>>>,
+    initializers: Vec<Box<dyn Initializer<A::State>>>,
+}
+
+impl<A: App> HttpServiceBuilder<A> {
+    pub fn new(path_root: &str, app_context: &AppContext) -> Self {
+        #[cfg(feature = "open-api")]
+        let app_name = app_context.config.app.name.clone();
+        Self {
+            router: default_routes(path_root, &app_context.config),
+            #[cfg(feature = "open-api")]
+            api_docs: Box::new(move |api| {
+                api.title(&app_name).description(&format!("# {}", app_name))
+            }),
+            middleware: default_middleware(),
+            initializers: default_initializers(),
+        }
+    }
+
+    pub fn build(self, context: &AppContext, state: &A::State) -> anyhow::Result<HttpService> {
+        #[cfg(not(feature = "open-api"))]
+        let router = self.router;
+
+        #[cfg(feature = "open-api")]
+        let (router, api) = {
+            let mut api = OpenApi::default();
+            let api_docs = self.api_docs;
+            let router = self.router.finish_api_with(&mut api, api_docs);
+            // Arc is very important here or we will face massive memory and performance issues
+            let api = Arc::new(api);
+            let router = router.layer(Extension(api.clone()));
+            (router, api)
+        };
+
+        let router = router.with_state::<()>(state.clone());
+
+        let initializers = self
+            .initializers
+            .into_iter()
+            .filter(|initializer| initializer.enabled(context, state))
+            .unique_by(|initializer| initializer.name())
+            .sorted_by(|a, b| Ord::cmp(&a.priority(context, state), &b.priority(context, state)))
+            .collect_vec();
+
+        let router = initializers
+            .iter()
+            .try_fold(router, |router, initializer| {
+                initializer.after_router(router, context, state)
+            })?;
+
+        let router = initializers
+            .iter()
+            .try_fold(router, |router, initializer| {
+                initializer.before_middleware(router, context, state)
+            })?;
+
+        info!("Installing middleware. Note: the order of installation is the inverse of the order middleware will run when handling a request.");
+        let router = self
+            .middleware
+            .into_iter()
+            .filter(|middleware| middleware.enabled(context, state))
+            .unique_by(|middleware| middleware.name())
+            .sorted_by(|a, b| Ord::cmp(&a.priority(context, state), &b.priority(context, state)))
+            // Reverse due to how Axum's `Router#layer` method adds middleware.
+            .rev()
+            .try_fold(router, |router, middleware| {
+                info!("Installing middleware: `{}`", middleware.name());
+                middleware.install(router, context, state)
+            })?;
+
+        let router = initializers
+            .iter()
+            .try_fold(router, |router, initializer| {
+                initializer.after_middleware(router, context, state)
+            })?;
+
+        let router = initializers
+            .iter()
+            .try_fold(router, |router, initializer| {
+                initializer.before_serve(router, context, state)
+            })?;
+
+        Ok(HttpService {
+            router,
+            #[cfg(feature = "open-api")]
+            api,
+        })
+    }
+
+    #[cfg(not(feature = "open-api"))]
+    pub fn router(mut self, router: Router<A::State>) -> Self {
+        self.router = self.router.merge(router);
+        self
+    }
+
+    #[cfg(feature = "open-api")]
+    pub fn router(mut self, router: ApiRouter<A::State>) -> Self {
+        self.router = self.router.merge(router);
+        self
+    }
+
+    #[cfg(feature = "open-api")]
+    pub fn api_docs(mut self, api_docs: Box<dyn Fn(TransformOpenApi) -> TransformOpenApi>) -> Self {
+        self.api_docs = api_docs;
+        self
+    }
+
+    pub fn initializer(mut self, initializer: Box<dyn Initializer<A::State>>) -> Self {
+        self.initializers.push(initializer);
+        self
+    }
+
+    pub fn middleware(mut self, middleware: Box<dyn Middleware<A::State>>) -> Self {
+        self.middleware.push(middleware);
+        self
+    }
+}

--- a/src/service/http/mod.rs
+++ b/src/service/http/mod.rs
@@ -1,0 +1,2 @@
+pub mod http_service;
+pub mod http_service_builder;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -7,11 +7,30 @@ use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 pub mod http;
+pub mod registry;
 
-// Todo: add doc comments
-// Todo: add/re-arrange app config fields to allow configuring services via app config
+/// Trait to represent a service (e.g., a persistent task) to run in the app. Example services
+/// include, but are not limited to: an [http API][crate::service::http::http_service::HttpService],
+/// a sidekiq processor, or a gRPC API.
 #[async_trait]
 pub trait AppService<A: App>: Send + Sync {
+    /// The name of the service.
+    fn name() -> String
+    where
+        Self: Sized;
+
+    /// Whether the service is enabled. If the service is not enabled, it will not be run.
+    fn enabled(context: &AppContext, state: &A::State) -> bool
+    where
+        Self: Sized;
+
+    /// Called when the app is starting up allow the service to handle CLI commands.
+    ///
+    /// Note: this is called after attempting to handle the CLI commands via [crate::cli::RunCommand]
+    /// implementations and won't be called if the command was already handled.
+    ///
+    /// See [crate::cli::RunCommand] for an explanation of the return values -- the behavior is
+    /// the same.
     #[cfg(feature = "cli")]
     async fn handle_cli(
         &self,
@@ -23,10 +42,27 @@ pub trait AppService<A: App>: Send + Sync {
         Ok(false)
     }
 
+    /// Run the service in a new tokio task.
+    ///
+    /// * cancel_token - A tokio [CancellationToken] to use as a signal to gracefully shut down
+    /// the service.
     async fn run(
         &self,
         app_context: Arc<AppContext>,
         app_state: Arc<A::State>,
         cancel_token: CancellationToken,
     ) -> anyhow::Result<()>;
+}
+
+/// Trait used to build an [AppService]. It's not a requirement that services implement this
+/// trait; it is provided as a convenience. A [builder][AppServiceBuilder] can be provided to
+/// the [ServiceRegistry][crate::service::registry::ServiceRegistry] instead of an [AppService],
+/// in which case the [ServiceRegistry][crate::service::registry::ServiceRegistry] will only
+/// build and register the service if [AppService::enabled] is `true`.
+pub trait AppServiceBuilder<A, S>
+where
+    A: App,
+    S: AppService<A>,
+{
+    fn build(self, context: &AppContext, state: &A::State) -> anyhow::Result<S>;
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,0 +1,32 @@
+use crate::app::App;
+use crate::app_context::AppContext;
+#[cfg(feature = "cli")]
+use crate::cli::RoadsterCli;
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+pub mod http;
+
+// Todo: add doc comments
+// Todo: add/re-arrange app config fields to allow configuring services via app config
+#[async_trait]
+pub trait AppService<A: App>: Send + Sync {
+    #[cfg(feature = "cli")]
+    async fn handle_cli(
+        &self,
+        _roadster_cli: &RoadsterCli,
+        _app_cli: &A::Cli,
+        _app_context: &AppContext,
+        _app_state: &A::State,
+    ) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+
+    async fn run(
+        &self,
+        app_context: Arc<AppContext>,
+        app_state: Arc<A::State>,
+        cancel_token: CancellationToken,
+    ) -> anyhow::Result<()>;
+}

--- a/src/service/registry.rs
+++ b/src/service/registry.rs
@@ -1,0 +1,67 @@
+use crate::app::App;
+use crate::app_context::AppContext;
+use crate::service::{AppService, AppServiceBuilder};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use tracing::info;
+
+/// Registry for [AppService]s that will be run in the app.
+pub struct ServiceRegistry<A>
+where
+    A: App + ?Sized,
+{
+    pub(crate) context: Arc<AppContext>,
+    pub(crate) state: Arc<A::State>,
+    pub(crate) services: BTreeMap<String, Box<dyn AppService<A>>>,
+}
+
+impl<A: App> ServiceRegistry<A> {
+    pub(crate) fn new(context: Arc<AppContext>, state: Arc<A::State>) -> Self {
+        Self {
+            context,
+            state,
+            services: Default::default(),
+        }
+    }
+
+    /// Register a new service. If the service is not enabled (e.g., [AppService::enabled] is `false`),
+    /// the service will not be registered.
+    pub fn register_service<S>(&mut self, service: S) -> anyhow::Result<()>
+    where
+        S: AppService<A> + 'static,
+    {
+        if !S::enabled(&self.context, &self.state) {
+            info!(service = %S::name(), "Service is not enabled, skipping registration");
+            return Ok(());
+        }
+        self.register_unchecked(service)
+    }
+
+    /// Build and register a new service. If the service is not enabled (e.g.,
+    /// [AppService::enabled] is `false`), the service will not be built or registered.
+    pub fn register_builder<S, B>(&mut self, builder: B) -> anyhow::Result<()>
+    where
+        S: AppService<A> + 'static,
+        B: AppServiceBuilder<A, S>,
+    {
+        if !S::enabled(&self.context, &self.state) {
+            info!(service = %S::name(), "Service is not enabled, skipping building and registration");
+            return Ok(());
+        }
+
+        info!(service = %S::name(), "Building service");
+        let service = builder.build(&self.context, &self.state)?;
+
+        self.register_unchecked(service)
+    }
+
+    fn register_unchecked<S>(&mut self, service: S) -> anyhow::Result<()>
+    where
+        S: AppService<A> + 'static,
+    {
+        info!(service = %S::name(), "Registering service");
+
+        self.services.insert(S::name(), Box::new(service));
+        Ok(())
+    }
+}

--- a/src/worker/registry.rs
+++ b/src/worker/registry.rs
@@ -47,7 +47,7 @@ where
         W: AppWorker<A, Args> + 'static,
     {
         let class_name = W::class_name();
-        debug!(worker = class_name, "Registering worker");
+        debug!(worker = %class_name, "Registering worker");
         self.registered_workers.insert(class_name.clone());
         let roadster_worker = RoadsterWorker::new(worker, self.state.clone());
         self.processor.register(roadster_worker);
@@ -71,7 +71,7 @@ where
         W: AppWorker<A, Args> + 'static,
     {
         let class_name = W::class_name();
-        debug!(worker = class_name, "Registering periodic worker");
+        debug!(worker = %class_name, "Registering periodic worker");
         let roadster_worker = RoadsterWorker::new(worker, self.state.clone());
         let builder = builder.args(args)?;
         let job_json = serde_json::to_string(&builder.into_periodic_job(class_name)?)?;


### PR DESCRIPTION
Add an `AppService` trait to allow consumers to define custom services that will be run as tokio tasks. This is similar (I believe) to Laraval's `Provider` concept.

Use the `AppService` trait to add an HTTP server using Axum instead of putting http/axum specific methods directly on the `App` trait