### PR TITLE
Remove `lazy_static` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ strum_macros = "0.26.2"
 itertools = "0.12.1"
 serde_json = "1.0.116"
 toml = "0.8.12"
-lazy_static = "1.4.0"
 url = { version = "2.5.0", features = ["serde"] }
 uuid = { version = "1.8.0", features = ["v4", "serde"] }
 futures-core = "0.3.30"


### PR DESCRIPTION
The dependency is not used, and should be replaced by `once_cell` the functionality is needed.