### PR TITLE
Disallow registering things multiple times

### DIFF
--- a/examples/minimal/src/app.rs
+++ b/examples/minimal/src/app.rs
@@ -30,14 +30,17 @@ impl RoadsterApp for App {
         state: Arc<Self::State>,
     ) -> anyhow::Result<()> {
         registry
-            .register_builder(HttpService::builder(BASE, &context).router(controller::routes(BASE)))
+            .register_builder(
+                HttpService::builder(BASE, &context, state.as_ref())
+                    .router(controller::routes(BASE)),
+            )
             .await?;
 
         registry
             .register_builder(
                 SidekiqWorkerService::builder(context.clone(), state.clone())
                     .await?
-                    .register_app_worker(ExampleWorker::build(&state)),
+                    .register_app_worker(ExampleWorker::build(&state))?,
             )
             .await?;
 

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -40,6 +40,7 @@ pub fn default_routes<S>(parent: &str, config: &AppConfig) -> ApiRouter<S>
 where
     S: Clone + Send + Sync + 'static + Into<Arc<AppContext>>,
 {
+    // Todo: Allow disabling the default routes
     ApiRouter::new()
         .merge(ping::routes(parent))
         .merge(health::routes(parent))

--- a/src/service/http/initializer/default.rs
+++ b/src/service/http/initializer/default.rs
@@ -1,6 +1,16 @@
+use crate::app_context::AppContext;
 use crate::service::http::initializer::normalize_path::NormalizePathInitializer;
 use crate::service::http::initializer::Initializer;
+use std::collections::BTreeMap;
 
-pub fn default_initializers<S>() -> Vec<Box<dyn Initializer<S>>> {
-    vec![Box::new(NormalizePathInitializer)]
+pub fn default_initializers<S>(
+    context: &AppContext,
+    state: &S,
+) -> BTreeMap<String, Box<dyn Initializer<S>>> {
+    let initializers: Vec<Box<dyn Initializer<S>>> = vec![Box::new(NormalizePathInitializer)];
+    initializers
+        .into_iter()
+        .filter(|initializer| initializer.enabled(context, state))
+        .map(|initializer| (initializer.name(), initializer))
+        .collect()
 }

--- a/src/service/http/service.rs
+++ b/src/service/http/service.rs
@@ -86,8 +86,12 @@ impl<A: App> AppService<A> for HttpService {
 
 impl HttpService {
     /// Create a new [HttpServiceBuilder].
-    pub fn builder<A: App>(path_root: &str, context: &AppContext) -> HttpServiceBuilder<A> {
-        HttpServiceBuilder::new(path_root, context)
+    pub fn builder<A: App>(
+        path_root: &str,
+        context: &AppContext,
+        state: &A::State,
+    ) -> HttpServiceBuilder<A> {
+        HttpServiceBuilder::new(path_root, context, state)
     }
 
     /// List the available HTTP API routes.


### PR DESCRIPTION
Update the following to thrown an error if a duplicate resource is registered:
- Worker service builder -- disallow duplicate workers or periodic jobs from being registered
- Http service builder -- disallow duplicate middleware or initializers from being registered. Note: Axum's built-in behavior is to disallow duplicate routes, so we don't need to handle that ourselves.
- Service registry -- disallow duplicate services from being registered. Note: we may want to allow this in the future -- it _may_ be useful, but will wait until we get a feature request for this before allowing it by default.