### PR TITLE
Fix codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+# The config file can be validated using https://api.codecov.io/validate
+# `curl -X POST --data-binary @codecov.yml https://codecov.io/validate`
+#
 # https://docs.codecov.com/docs/common-recipe-list
 
 coverage:
@@ -6,9 +9,9 @@ coverage:
       default:
         target: auto
         threshold: 1%
-      github_checks:
-        # Install the codecov browser extension to see coverage annotations in GitHub.
-        # https://docs.codecov.com/docs/the-codecov-browser-extension
-        annotations: false
-      comment:
-        require_changes: true
+github_checks:
+  # Install the codecov browser extension to see coverage annotations in GitHub.
+  # https://docs.codecov.com/docs/the-codecov-browser-extension
+  annotations: false
+comment:
+  require_changes: true


### PR DESCRIPTION
The codecov config was invalid. Update it and validate using `https://api.codecov.io/validate`.