### PR TITLE
Add methods to AppContext instead of direct field access

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -161,8 +161,8 @@ where
     }
 
     #[cfg(feature = "db-sql")]
-    if context.config.database.auto_migrate {
-        A::M::up(&context.db, None).await?;
+    if context.config().database.auto_migrate {
+        A::M::up(context.db(), None).await?;
     }
 
     let cancel_token = CancellationToken::new();
@@ -352,7 +352,7 @@ where
     F: Future<Output = anyhow::Result<T>> + Send + 'static,
 {
     let result = f.await;
-    if result.is_err() && context.config.app.shutdown_on_error {
+    if result.is_err() && context.config().app.shutdown_on_error {
         cancellation_token.cancel();
     }
     result
@@ -375,7 +375,7 @@ where
     #[cfg(feature = "db-sql")]
     let db_close_result = {
         info!("Closing the DB connection pool.");
-        context.as_ref().clone().db.close().await
+        context.db().clone().close().await
     };
 
     // Futures are lazy -- the custom `app_graceful_shutdown` future won't run until we call `await` on it.

--- a/src/app_context.rs
+++ b/src/app_context.rs
@@ -6,20 +6,8 @@ use sea_orm::DatabaseConnection;
 use crate::config::app_config::AppConfig;
 
 #[derive(Debug, Clone)]
-#[allow(clippy::manual_non_exhaustive)]
 pub struct AppContext {
-    pub config: AppConfig,
-    #[cfg(feature = "db-sql")]
-    pub db: DatabaseConnection,
-    #[cfg(feature = "sidekiq")]
-    pub redis_enqueue: sidekiq::RedisPool,
-    /// The Redis connection pool used by [sidekiq::Processor] to fetch Sidekiq jobs from Redis.
-    /// May be `None` if the [fetch_pool.max_connections][crate::config::service::worker::sidekiq::ConnectionPool]
-    /// config is set to zero, in which case the [sidekiq::Processor] would also not be started.
-    #[cfg(feature = "sidekiq")]
-    pub redis_fetch: Option<sidekiq::RedisPool>,
-    // Prevent consumers from directly creating an AppContext
-    _private: (),
+    inner: Arc<AppContextInner>,
 }
 
 impl AppContext {
@@ -29,7 +17,7 @@ impl AppContext {
         #[cfg(feature = "sidekiq")] redis_enqueue: sidekiq::RedisPool,
         #[cfg(feature = "sidekiq")] redis_fetch: Option<sidekiq::RedisPool>,
     ) -> anyhow::Result<Self> {
-        let context = Self {
+        let inner = AppContextInner {
             config,
             #[cfg(feature = "db-sql")]
             db,
@@ -37,10 +25,44 @@ impl AppContext {
             redis_enqueue,
             #[cfg(feature = "sidekiq")]
             redis_fetch,
-            _private: (),
         };
-        Ok(context)
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
     }
+
+    pub fn config(&self) -> &AppConfig {
+        &self.inner.config
+    }
+
+    #[cfg(feature = "db-sql")]
+    pub fn db(&self) -> &DatabaseConnection {
+        &self.inner.db
+    }
+
+    #[cfg(feature = "sidekiq")]
+    pub fn redis_enqueue(&self) -> &sidekiq::RedisPool {
+        &self.inner.redis_enqueue
+    }
+
+    #[cfg(feature = "sidekiq")]
+    pub fn redis_fetch(&self) -> Option<&sidekiq::RedisPool> {
+        self.inner.redis_fetch.as_ref()
+    }
+}
+
+#[derive(Debug)]
+struct AppContextInner {
+    config: AppConfig,
+    #[cfg(feature = "db-sql")]
+    db: DatabaseConnection,
+    #[cfg(feature = "sidekiq")]
+    redis_enqueue: sidekiq::RedisPool,
+    /// The Redis connection pool used by [sidekiq::Processor] to fetch Sidekiq jobs from Redis.
+    /// May be `None` if the [fetch_pool.max_connections][crate::config::service::worker::sidekiq::ConnectionPool]
+    /// config is set to zero, in which case the [sidekiq::Processor] would also not be started.
+    #[cfg(feature = "sidekiq")]
+    redis_fetch: Option<sidekiq::RedisPool>,
 }
 
 /// Implemented so consumers can use [AppContext] as their [crate::app::App::State] if they want.

--- a/src/auth/jwt/mod.rs
+++ b/src/auth/jwt/mod.rs
@@ -61,9 +61,9 @@ where
         let state: Arc<AppContext> = state.clone().into();
         let token: TokenData<C> = decode_auth_token(
             auth_header.0.token(),
-            &state.config.auth.jwt.secret,
-            &state.config.auth.jwt.claims.audience,
-            &state.config.auth.jwt.claims.required_claims,
+            &state.config().auth.jwt.secret,
+            &state.config().auth.jwt.claims.audience,
+            &state.config().auth.jwt.claims.required_claims,
         )?;
         let token = Jwt {
             header: token.header,

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -47,20 +47,21 @@ where
 {
     async fn run(&self, _app: &A, cli: &RoadsterCli, context: &AppContext) -> anyhow::Result<bool> {
         if is_destructive(self) && !cli.allow_dangerous(context) {
-            bail!("Running destructive command `{:?}` is not allowed in environment `{:?}`. To override, provide the `--allow-dangerous` CLI arg.", self, context.config.environment);
+            bail!("Running destructive command `{:?}` is not allowed in environment `{:?}`. To override, provide the `--allow-dangerous` CLI arg.", self, context.config().environment);
         } else if is_destructive(self) {
             warn!(
                 "Running destructive command `{:?}` in environment `{:?}`",
-                self, context.config.environment
+                self,
+                context.config().environment
             );
         }
         match self {
-            MigrateCommand::Up(args) => A::M::up(&context.db, args.steps).await?,
-            MigrateCommand::Down(args) => A::M::down(&context.db, args.steps).await?,
-            MigrateCommand::Refresh => A::M::refresh(&context.db).await?,
-            MigrateCommand::Reset => A::M::reset(&context.db).await?,
-            MigrateCommand::Fresh => A::M::fresh(&context.db).await?,
-            MigrateCommand::Status => A::M::status(&context.db).await?,
+            MigrateCommand::Up(args) => A::M::up(context.db(), args.steps).await?,
+            MigrateCommand::Down(args) => A::M::down(context.db(), args.steps).await?,
+            MigrateCommand::Refresh => A::M::refresh(context.db()).await?,
+            MigrateCommand::Reset => A::M::reset(context.db()).await?,
+            MigrateCommand::Fresh => A::M::fresh(context.db()).await?,
+            MigrateCommand::Status => A::M::status(context.db()).await?,
         };
         Ok(true)
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -71,7 +71,7 @@ pub struct RoadsterCli {
 
 impl RoadsterCli {
     pub fn allow_dangerous(&self, context: &AppContext) -> bool {
-        context.config.environment != Environment::Production || self.allow_dangerous
+        context.config().environment != Environment::Production || self.allow_dangerous
     }
 }
 

--- a/src/cli/print_config.rs
+++ b/src/cli/print_config.rs
@@ -41,19 +41,19 @@ where
     ) -> anyhow::Result<bool> {
         match self.format {
             Format::Debug => {
-                info!("{:?}", context.config)
+                info!("{:?}", context.config())
             }
             Format::Json => {
-                info!("{}", serde_json::to_string(&context.config)?)
+                info!("{}", serde_json::to_string(&context.config())?)
             }
             Format::JsonPretty => {
-                info!("{}", serde_json::to_string_pretty(&context.config)?)
+                info!("{}", serde_json::to_string_pretty(&context.config())?)
             }
             Format::Toml => {
-                info!("{}", toml::to_string(&context.config)?)
+                info!("{}", toml::to_string(&context.config())?)
             }
             Format::TomlPretty => {
-                info!("{}", toml::to_string_pretty(&context.config)?)
+                info!("{}", toml::to_string_pretty(&context.config())?)
             }
         }
 

--- a/src/config/service/http/initializer.rs
+++ b/src/config/service/http/initializer.rs
@@ -77,7 +77,7 @@ impl CommonConfig {
     pub fn enabled(&self, context: &AppContext) -> bool {
         self.enable.unwrap_or(
             context
-                .config
+                .config()
                 .service
                 .http
                 .custom

--- a/src/config/service/http/middleware.rs
+++ b/src/config/service/http/middleware.rs
@@ -138,8 +138,15 @@ impl CommonConfig {
     }
 
     pub fn enabled(&self, context: &AppContext) -> bool {
-        self.enable
-            .unwrap_or(context.config.service.http.custom.middleware.default_enable)
+        self.enable.unwrap_or(
+            context
+                .config()
+                .service
+                .http
+                .custom
+                .middleware
+                .default_enable,
+        )
     }
 }
 

--- a/src/config/service/mod.rs
+++ b/src/config/service/mod.rs
@@ -30,7 +30,8 @@ pub struct CommonConfig {
 
 impl CommonConfig {
     pub fn enabled(&self, context: &AppContext) -> bool {
-        self.enable.unwrap_or(context.config.service.default_enable)
+        self.enable
+            .unwrap_or(context.config().service.default_enable)
     }
 }
 

--- a/src/controller/health.rs
+++ b/src/controller/health.rs
@@ -112,7 +112,7 @@ where
     #[cfg(feature = "db-sql")]
     let db = {
         let db_timer = Instant::now();
-        let db_status = if ping_db(&state.db).await.is_ok() {
+        let db_status = if ping_db(state.db()).await.is_ok() {
             Status::Ok
         } else {
             Status::Err
@@ -127,9 +127,9 @@ where
     };
 
     #[cfg(feature = "sidekiq")]
-    let redis_enqueue = redis_health(&state.redis_enqueue).await;
+    let redis_enqueue = redis_health(state.redis_enqueue()).await;
     #[cfg(feature = "sidekiq")]
-    let redis_fetch = if let Some(redis_fetch) = state.redis_fetch.as_ref() {
+    let redis_fetch = if let Some(redis_fetch) = state.redis_fetch() {
         Some(redis_health(redis_fetch).await)
     } else {
         None

--- a/src/service/http/builder.rs
+++ b/src/service/http/builder.rs
@@ -39,9 +39,9 @@ pub struct HttpServiceBuilder<A: App> {
 impl<A: App> HttpServiceBuilder<A> {
     pub fn new(path_root: &str, context: &AppContext, state: &A::State) -> Self {
         #[cfg(feature = "open-api")]
-        let app_name = context.config.app.name.clone();
+        let app_name = context.config().app.name.clone();
         Self {
-            router: default_routes(path_root, &context.config),
+            router: default_routes(path_root, context.config()),
             #[cfg(feature = "open-api")]
             api_docs: Box::new(move |api| {
                 api.title(&app_name).description(&format!("# {}", app_name))

--- a/src/service/http/initializer/normalize_path.rs
+++ b/src/service/http/initializer/normalize_path.rs
@@ -18,7 +18,7 @@ impl<S> Initializer<S> for NormalizePathInitializer {
 
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -30,7 +30,7 @@ impl<S> Initializer<S> for NormalizePathInitializer {
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
-            .config
+            .config()
             .service
             .http
             .custom

--- a/src/service/http/middleware/catch_panic.rs
+++ b/src/service/http/middleware/catch_panic.rs
@@ -16,7 +16,7 @@ impl<S> Middleware<S> for CatchPanicMiddleware {
 
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -28,7 +28,7 @@ impl<S> Middleware<S> for CatchPanicMiddleware {
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
-            .config
+            .config()
             .service
             .http
             .custom

--- a/src/service/http/middleware/compression.rs
+++ b/src/service/http/middleware/compression.rs
@@ -22,7 +22,7 @@ impl<S> Middleware<S> for ResponseCompressionMiddleware {
 
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -34,7 +34,7 @@ impl<S> Middleware<S> for ResponseCompressionMiddleware {
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -59,7 +59,7 @@ impl<S> Middleware<S> for RequestDecompressionMiddleware {
 
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -71,7 +71,7 @@ impl<S> Middleware<S> for RequestDecompressionMiddleware {
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
-            .config
+            .config()
             .service
             .http
             .custom

--- a/src/service/http/middleware/request_id.rs
+++ b/src/service/http/middleware/request_id.rs
@@ -44,7 +44,7 @@ impl<S> Middleware<S> for SetRequestIdMiddleware {
 
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -56,7 +56,7 @@ impl<S> Middleware<S> for SetRequestIdMiddleware {
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -68,7 +68,7 @@ impl<S> Middleware<S> for SetRequestIdMiddleware {
 
     fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
         let header_name = &context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -95,7 +95,7 @@ impl<S> Middleware<S> for PropagateRequestIdMiddleware {
 
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -107,7 +107,7 @@ impl<S> Middleware<S> for PropagateRequestIdMiddleware {
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -119,7 +119,7 @@ impl<S> Middleware<S> for PropagateRequestIdMiddleware {
 
     fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
         let header_name = &context
-            .config
+            .config()
             .service
             .http
             .custom

--- a/src/service/http/middleware/sensitive_headers.rs
+++ b/src/service/http/middleware/sensitive_headers.rs
@@ -63,7 +63,7 @@ impl<S> Middleware<S> for SensitiveRequestHeadersMiddleware {
 
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -75,7 +75,7 @@ impl<S> Middleware<S> for SensitiveRequestHeadersMiddleware {
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -86,7 +86,7 @@ impl<S> Middleware<S> for SensitiveRequestHeadersMiddleware {
     }
     fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
         let headers = context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -111,7 +111,7 @@ impl<S> Middleware<S> for SensitiveResponseHeadersMiddleware {
 
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -123,7 +123,7 @@ impl<S> Middleware<S> for SensitiveResponseHeadersMiddleware {
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -134,7 +134,7 @@ impl<S> Middleware<S> for SensitiveResponseHeadersMiddleware {
     }
     fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
         let headers = context
-            .config
+            .config()
             .service
             .http
             .custom

--- a/src/service/http/middleware/size_limit.rs
+++ b/src/service/http/middleware/size_limit.rs
@@ -30,7 +30,7 @@ impl<S> Middleware<S> for RequestBodyLimitMiddleware {
 
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -42,7 +42,7 @@ impl<S> Middleware<S> for RequestBodyLimitMiddleware {
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -54,7 +54,7 @@ impl<S> Middleware<S> for RequestBodyLimitMiddleware {
 
     fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
         let limit = &context
-            .config
+            .config()
             .service
             .http
             .custom

--- a/src/service/http/middleware/timeout.rs
+++ b/src/service/http/middleware/timeout.rs
@@ -30,7 +30,7 @@ impl<S> Middleware<S> for TimeoutMiddleware {
 
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -42,7 +42,7 @@ impl<S> Middleware<S> for TimeoutMiddleware {
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -54,7 +54,7 @@ impl<S> Middleware<S> for TimeoutMiddleware {
 
     fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
         let timeout = &context
-            .config
+            .config()
             .service
             .http
             .custom

--- a/src/service/http/middleware/tracing.rs
+++ b/src/service/http/middleware/tracing.rs
@@ -23,7 +23,7 @@ impl<S> Middleware<S> for TracingMiddleware {
 
     fn enabled(&self, context: &AppContext, _state: &S) -> bool {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -35,7 +35,7 @@ impl<S> Middleware<S> for TracingMiddleware {
 
     fn priority(&self, context: &AppContext, _state: &S) -> i32 {
         context
-            .config
+            .config()
             .service
             .http
             .custom
@@ -47,7 +47,7 @@ impl<S> Middleware<S> for TracingMiddleware {
 
     fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
         let request_id_header_name = &context
-            .config
+            .config()
             .service
             .http
             .custom

--- a/src/service/http/service.rs
+++ b/src/service/http/service.rs
@@ -35,7 +35,7 @@ impl<A: App> AppService<A> for HttpService {
     }
 
     fn enabled(context: &AppContext, _state: &A::State) -> bool {
-        context.config.service.http.common.enabled(context)
+        context.config().service.http.common.enabled(context)
     }
 
     #[cfg(feature = "cli")]
@@ -72,7 +72,7 @@ impl<A: App> AppService<A> for HttpService {
         _app_state: Arc<A::State>,
         cancel_token: CancellationToken,
     ) -> anyhow::Result<()> {
-        let server_addr = app_context.config.service.http.custom.address.url();
+        let server_addr = app_context.config().service.http.custom.address.url();
         info!("Server will start at {server_addr}");
 
         let app_listener = tokio::net::TcpListener::bind(server_addr).await?;

--- a/src/service/worker/sidekiq/app_worker.rs
+++ b/src/service/worker/sidekiq/app_worker.rs
@@ -59,7 +59,7 @@ where
     /// [sidekiq::RedisPool] from inside the [state][App::State].
     async fn enqueue(state: &A::State, args: Args) -> anyhow::Result<()> {
         let context: Arc<AppContext> = state.clone().into();
-        Self::perform_async(&context.redis_enqueue, args).await?;
+        Self::perform_async(context.redis_enqueue(), args).await?;
         Ok(())
     }
 
@@ -81,7 +81,7 @@ where
     fn max_retries(&self, state: &A::State) -> usize {
         let context: Arc<AppContext> = state.clone().into();
         context
-            .config
+            .config()
             .service
             .sidekiq
             .custom
@@ -94,7 +94,13 @@ where
     /// The default implementation uses the value from the app's config file.
     fn timeout(&self, state: &A::State) -> bool {
         let context: Arc<AppContext> = state.clone().into();
-        context.config.service.sidekiq.custom.worker_config.timeout
+        context
+            .config()
+            .service
+            .sidekiq
+            .custom
+            .worker_config
+            .timeout
     }
 
     /// See [AppWorkerConfig::max_duration].
@@ -103,7 +109,7 @@ where
     fn max_duration(&self, state: &A::State) -> Duration {
         let context: Arc<AppContext> = state.clone().into();
         context
-            .config
+            .config()
             .service
             .sidekiq
             .custom
@@ -117,7 +123,7 @@ where
     fn disable_argument_coercion(&self, state: &A::State) -> bool {
         let context: Arc<AppContext> = state.clone().into();
         context
-            .config
+            .config()
             .service
             .sidekiq
             .custom

--- a/src/service/worker/sidekiq/service.rs
+++ b/src/service/worker/sidekiq/service.rs
@@ -26,7 +26,7 @@ impl<A: App> AppService<A> for SidekiqWorkerService {
     where
         Self: Sized,
     {
-        let sidekiq_config = &context.config.service.sidekiq;
+        let sidekiq_config = &context.config().service.sidekiq;
         if !sidekiq_config.common.enabled(context) {
             debug!("Sidekiq is not enabled in the config.");
             return false;
@@ -39,7 +39,7 @@ impl<A: App> AppService<A> for SidekiqWorkerService {
             debug!("Sidekiq configured with 0 worker queues.");
             return false;
         }
-        if context.redis_fetch.is_none() {
+        if context.redis_fetch().is_none() {
             debug!("No 'redis-fetch' pool connections available.");
             return false;
         }


### PR DESCRIPTION
This makes it slightly more ergonomic to contain the app context state with an "inner" type that's wrapped by an Arc.

This also allows consumers to disallow direct access to specific fields using clippy's
[disallowed-methods](https://rust-lang.github.io/rust-clippy/master/index.html#/disallowed_methods) lint. This is useful, for example, if consumers want to provide their own method for accessing the DB that performs some logic before/after the DB operations, e.g. for implementing RLS.