### PR TITLE
Custom state as member of `AppContext`

### DIFF
--- a/examples/minimal/src/app_state.rs
+++ b/examples/minimal/src/app_state.rs
@@ -2,29 +2,4 @@
 // to implement the required traits used to convert it to/from `AppState`.
 #![allow(clippy::disallowed_types)]
 
-use std::sync::Arc;
-
-use roadster::app_context::AppContext;
-
-#[derive(Debug, Clone)]
-pub struct AppState {
-    context: Arc<AppContext>,
-}
-
-impl AppState {
-    pub fn new(ctx: Arc<AppContext>) -> Self {
-        Self { context: ctx }
-    }
-}
-
-impl From<Arc<AppContext>> for AppState {
-    fn from(value: Arc<AppContext>) -> Self {
-        AppState::new(value)
-    }
-}
-
-impl From<AppState> for Arc<AppContext> {
-    fn from(value: AppState) -> Self {
-        value.context
-    }
-}
+pub type AppState = ();

--- a/examples/minimal/src/cli/mod.rs
+++ b/examples/minimal/src/cli/mod.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use clap::{Parser, Subcommand};
+use roadster::app_context::AppContext;
 
 use roadster::cli::RunCommand;
 
@@ -18,9 +19,14 @@ pub struct AppCli {
 #[async_trait]
 impl RunCommand<App> for AppCli {
     #[allow(clippy::disallowed_types)]
-    async fn run(&self, app: &App, cli: &AppCli, state: &AppState) -> anyhow::Result<bool> {
+    async fn run(
+        &self,
+        app: &App,
+        cli: &AppCli,
+        context: &AppContext<AppState>,
+    ) -> anyhow::Result<bool> {
         if let Some(command) = self.command.as_ref() {
-            command.run(app, cli, state).await
+            command.run(app, cli, context).await
         } else {
             Ok(false)
         }
@@ -35,7 +41,12 @@ pub enum AppCommand {}
 
 #[async_trait]
 impl RunCommand<App> for AppCommand {
-    async fn run(&self, _app: &App, _cli: &AppCli, _state: &AppState) -> anyhow::Result<bool> {
+    async fn run(
+        &self,
+        _app: &App,
+        _cli: &AppCli,
+        _context: &AppContext<AppState>,
+    ) -> anyhow::Result<bool> {
         Ok(false)
     }
 }

--- a/examples/minimal/src/controller/example.rs
+++ b/examples/minimal/src/controller/example.rs
@@ -5,6 +5,7 @@ use aide::axum::ApiRouter;
 use aide::transform::TransformOperation;
 use axum::extract::State;
 use axum::Json;
+use roadster::app_context::AppContext;
 use roadster::controller::build_path;
 use roadster::service::worker::sidekiq::app_worker::AppWorker;
 use roadster::view::app_error::AppError;
@@ -15,7 +16,7 @@ use tracing::instrument;
 const BASE: &str = "/example";
 const TAG: &str = "Example";
 
-pub fn routes(parent: &str) -> ApiRouter<AppState> {
+pub fn routes(parent: &str) -> ApiRouter<AppContext<AppState>> {
     let root = build_path(parent, BASE);
 
     ApiRouter::new().api_route(&root, get_with(example_get, example_get_docs))
@@ -26,7 +27,9 @@ pub fn routes(parent: &str) -> ApiRouter<AppState> {
 pub struct ExampleResponse {}
 
 #[instrument(skip_all)]
-async fn example_get(State(state): State<AppState>) -> Result<Json<ExampleResponse>, AppError> {
+async fn example_get(
+    State(state): State<AppContext<AppState>>,
+) -> Result<Json<ExampleResponse>, AppError> {
     ExampleWorker::enqueue(&state, "Example".to_string()).await?;
     Ok(Json(ExampleResponse {}))
 }

--- a/examples/minimal/src/controller/mod.rs
+++ b/examples/minimal/src/controller/mod.rs
@@ -1,8 +1,9 @@
 use crate::app_state::AppState;
 use aide::axum::ApiRouter;
+use roadster::app_context::AppContext;
 
 pub mod example;
 
-pub fn routes(parent: &str) -> ApiRouter<AppState> {
+pub fn routes(parent: &str) -> ApiRouter<AppContext<AppState>> {
     ApiRouter::new().merge(example::routes(parent))
 }

--- a/examples/minimal/src/worker/example.rs
+++ b/examples/minimal/src/worker/example.rs
@@ -1,6 +1,7 @@
 use crate::app::App;
 use crate::app_state::AppState;
 use async_trait::async_trait;
+use roadster::app_context::AppContext;
 use roadster::service::worker::sidekiq::app_worker::AppWorker;
 use sidekiq::Worker;
 use tracing::{info, instrument};
@@ -18,7 +19,7 @@ impl Worker<String> for ExampleWorker {
 
 #[async_trait]
 impl AppWorker<App, String> for ExampleWorker {
-    fn build(_state: &AppState) -> Self {
+    fn build(_context: &AppContext<AppState>) -> Self {
         Self {}
     }
 }

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -19,7 +19,12 @@ impl<A> RunRoadsterCommand<A> for MigrateArgs
 where
     A: App,
 {
-    async fn run(&self, app: &A, cli: &RoadsterCli, context: &AppContext) -> anyhow::Result<bool> {
+    async fn run(
+        &self,
+        app: &A,
+        cli: &RoadsterCli,
+        context: &AppContext<A::State>,
+    ) -> anyhow::Result<bool> {
         self.command.run(app, cli, context).await
     }
 }
@@ -45,7 +50,12 @@ impl<A> RunRoadsterCommand<A> for MigrateCommand
 where
     A: App,
 {
-    async fn run(&self, _app: &A, cli: &RoadsterCli, context: &AppContext) -> anyhow::Result<bool> {
+    async fn run(
+        &self,
+        _app: &A,
+        cli: &RoadsterCli,
+        context: &AppContext<A::State>,
+    ) -> anyhow::Result<bool> {
         if is_destructive(self) && !cli.allow_dangerous(context) {
             bail!("Running destructive command `{:?}` is not allowed in environment `{:?}`. To override, provide the `--allow-dangerous` CLI arg.", self, context.config().environment);
         } else if is_destructive(self) {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -35,7 +35,12 @@ where
     ///     continue execution after the command is complete.
     /// * `Err(...)` - If the implementation experienced an error while handling the command. The
     ///     app should end execution after the command is complete.
-    async fn run(&self, app: &A, cli: &A::Cli, state: &A::State) -> anyhow::Result<bool>;
+    async fn run(
+        &self,
+        app: &A,
+        cli: &A::Cli,
+        context: &AppContext<A::State>,
+    ) -> anyhow::Result<bool>;
 }
 
 /// Internal version of [RunCommand] that uses the [RoadsterCli] and [AppContext] instead of
@@ -46,7 +51,12 @@ pub(crate) trait RunRoadsterCommand<A>
 where
     A: App,
 {
-    async fn run(&self, app: &A, cli: &RoadsterCli, context: &AppContext) -> anyhow::Result<bool>;
+    async fn run(
+        &self,
+        app: &A,
+        cli: &RoadsterCli,
+        context: &AppContext<A::State>,
+    ) -> anyhow::Result<bool>;
 }
 
 /// Roadster: The Roadster CLI provides various utilities for managing your application. If no subcommand
@@ -70,7 +80,7 @@ pub struct RoadsterCli {
 }
 
 impl RoadsterCli {
-    pub fn allow_dangerous(&self, context: &AppContext) -> bool {
+    pub fn allow_dangerous<S>(&self, context: &AppContext<S>) -> bool {
         context.config().environment != Environment::Production || self.allow_dangerous
     }
 }
@@ -80,7 +90,12 @@ impl<A> RunRoadsterCommand<A> for RoadsterCli
 where
     A: App,
 {
-    async fn run(&self, app: &A, cli: &RoadsterCli, context: &AppContext) -> anyhow::Result<bool> {
+    async fn run(
+        &self,
+        app: &A,
+        cli: &RoadsterCli,
+        context: &AppContext<A::State>,
+    ) -> anyhow::Result<bool> {
         if let Some(command) = self.command.as_ref() {
             command.run(app, cli, context).await
         } else {
@@ -102,7 +117,12 @@ impl<A> RunRoadsterCommand<A> for RoadsterCommand
 where
     A: App,
 {
-    async fn run(&self, app: &A, cli: &RoadsterCli, context: &AppContext) -> anyhow::Result<bool> {
+    async fn run(
+        &self,
+        app: &A,
+        cli: &RoadsterCli,
+        context: &AppContext<A::State>,
+    ) -> anyhow::Result<bool> {
         match self {
             RoadsterCommand::Roadster(args) => args.run(app, cli, context).await,
         }
@@ -120,7 +140,12 @@ impl<A> RunRoadsterCommand<A> for RoadsterArgs
 where
     A: App,
 {
-    async fn run(&self, app: &A, cli: &RoadsterCli, context: &AppContext) -> anyhow::Result<bool> {
+    async fn run(
+        &self,
+        app: &A,
+        cli: &RoadsterCli,
+        context: &AppContext<A::State>,
+    ) -> anyhow::Result<bool> {
         self.command.run(app, cli, context).await
     }
 }
@@ -151,7 +176,12 @@ impl<A> RunRoadsterCommand<A> for RoadsterSubCommand
 where
     A: App,
 {
-    async fn run(&self, app: &A, cli: &RoadsterCli, context: &AppContext) -> anyhow::Result<bool> {
+    async fn run(
+        &self,
+        app: &A,
+        cli: &RoadsterCli,
+        context: &AppContext<A::State>,
+    ) -> anyhow::Result<bool> {
         match self {
             #[cfg(feature = "open-api")]
             RoadsterSubCommand::ListRoutes(_) => {

--- a/src/cli/print_config.rs
+++ b/src/cli/print_config.rs
@@ -37,7 +37,7 @@ where
         &self,
         _app: &A,
         _cli: &RoadsterCli,
-        context: &AppContext,
+        context: &AppContext<A::State>,
     ) -> anyhow::Result<bool> {
         match self.format {
             Format::Debug => {

--- a/src/config/service/http/initializer.rs
+++ b/src/config/service/http/initializer.rs
@@ -74,7 +74,7 @@ impl CommonConfig {
         self
     }
 
-    pub fn enabled(&self, context: &AppContext) -> bool {
+    pub fn enabled<S>(&self, context: &AppContext<S>) -> bool {
         self.enable.unwrap_or(
             context
                 .config()

--- a/src/config/service/http/middleware.rs
+++ b/src/config/service/http/middleware.rs
@@ -137,7 +137,7 @@ impl CommonConfig {
         self
     }
 
-    pub fn enabled(&self, context: &AppContext) -> bool {
+    pub fn enabled<S>(&self, context: &AppContext<S>) -> bool {
         self.enable.unwrap_or(
             context
                 .config()

--- a/src/config/service/mod.rs
+++ b/src/config/service/mod.rs
@@ -29,7 +29,7 @@ pub struct CommonConfig {
 }
 
 impl CommonConfig {
-    pub fn enabled(&self, context: &AppContext) -> bool {
+    pub fn enabled<T>(&self, context: &AppContext<T>) -> bool {
         self.enable
             .unwrap_or(context.config().service.default_enable)
     }

--- a/src/controller/health.rs
+++ b/src/controller/health.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 #[cfg(feature = "sidekiq")]
 use std::time::Duration;
 use std::time::Instant;
@@ -39,9 +38,9 @@ const BASE: &str = "/_health";
 const TAG: &str = "Health";
 
 #[cfg(not(feature = "open-api"))]
-pub fn routes<S>(parent: &str) -> Router<S>
+pub fn routes<S>(parent: &str) -> Router<AppContext<S>>
 where
-    S: Clone + Send + Sync + 'static + Into<Arc<AppContext>>,
+    S: Clone + Send + Sync + 'static,
 {
     let root = build_path(parent, BASE);
 
@@ -49,9 +48,9 @@ where
 }
 
 #[cfg(feature = "open-api")]
-pub fn routes<S>(parent: &str) -> ApiRouter<S>
+pub fn routes<S>(parent: &str) -> ApiRouter<AppContext<S>>
 where
-    S: Clone + Send + Sync + 'static + Into<Arc<AppContext>>,
+    S: Clone + Send + Sync + 'static,
 {
     let root = build_path(parent, BASE);
 
@@ -101,14 +100,13 @@ pub enum Status {
 
 #[instrument(skip_all)]
 async fn health_get<S>(
-    #[cfg(any(feature = "sidekiq", feature = "db-sql"))] State(state): State<S>,
+    #[cfg(any(feature = "sidekiq", feature = "db-sql"))] State(state): State<AppContext<S>>,
 ) -> Result<Json<HeathCheckResponse>, AppError>
 where
-    S: Clone + Send + Sync + 'static + Into<Arc<AppContext>>,
+    S: Clone + Send + Sync + 'static,
 {
     let timer = Instant::now();
     #[cfg(any(feature = "sidekiq", feature = "db-sql"))]
-    let state: Arc<AppContext> = state.into();
     #[cfg(feature = "db-sql")]
     let db = {
         let db_timer = Instant::now();

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 #[cfg(feature = "open-api")]
 use aide::axum::ApiRouter;
 #[cfg(not(feature = "open-api"))]
@@ -26,9 +24,9 @@ pub fn build_path(parent: &str, child: &str) -> String {
 }
 
 #[cfg(not(feature = "open-api"))]
-pub fn default_routes<S>(parent: &str, _config: &AppConfig) -> Router<S>
+pub fn default_routes<S>(parent: &str, _config: &AppConfig) -> Router<AppContext<S>>
 where
-    S: Clone + Send + Sync + 'static + Into<Arc<AppContext>>,
+    S: Clone + Send + Sync + 'static,
 {
     Router::new()
         .merge(ping::routes(parent))
@@ -36,9 +34,9 @@ where
 }
 
 #[cfg(feature = "open-api")]
-pub fn default_routes<S>(parent: &str, config: &AppConfig) -> ApiRouter<S>
+pub fn default_routes<S>(parent: &str, config: &AppConfig) -> ApiRouter<AppContext<S>>
 where
-    S: Clone + Send + Sync + 'static + Into<Arc<AppContext>>,
+    S: Clone + Send + Sync + 'static,
 {
     // Todo: Allow disabling the default routes
     ApiRouter::new()

--- a/src/service/http/initializer/default.rs
+++ b/src/service/http/initializer/default.rs
@@ -4,13 +4,12 @@ use crate::service::http::initializer::Initializer;
 use std::collections::BTreeMap;
 
 pub fn default_initializers<S>(
-    context: &AppContext,
-    state: &S,
+    context: &AppContext<S>,
 ) -> BTreeMap<String, Box<dyn Initializer<S>>> {
     let initializers: Vec<Box<dyn Initializer<S>>> = vec![Box::new(NormalizePathInitializer)];
     initializers
         .into_iter()
-        .filter(|initializer| initializer.enabled(context, state))
+        .filter(|initializer| initializer.enabled(context))
         .map(|initializer| (initializer.name(), initializer))
         .collect()
 }

--- a/src/service/http/initializer/mod.rs
+++ b/src/service/http/initializer/mod.rs
@@ -10,7 +10,7 @@ use axum::Router;
 pub trait Initializer<S>: Send {
     fn name(&self) -> String;
 
-    fn enabled(&self, context: &AppContext, state: &S) -> bool;
+    fn enabled(&self, context: &AppContext<S>) -> bool;
 
     /// Used to determine the order in which the initializer will run during app initialization.
     /// Smaller numbers will run before larger numbers. For example, an initializer with priority
@@ -21,41 +21,25 @@ pub trait Initializer<S>: Send {
     ///
     /// If the order in which your initializer runs doesn't particularly matter, it's generally
     /// safe to set its priority as `0`.
-    fn priority(&self, context: &AppContext, state: &S) -> i32;
+    fn priority(&self, context: &AppContext<S>) -> i32;
 
-    fn after_router(
-        &self,
-        router: Router,
-        _context: &AppContext,
-        _state: &S,
-    ) -> anyhow::Result<Router> {
+    fn after_router(&self, router: Router, _context: &AppContext<S>) -> anyhow::Result<Router> {
         Ok(router)
     }
 
     fn before_middleware(
         &self,
         router: Router,
-        _context: &AppContext,
-        _state: &S,
+        _context: &AppContext<S>,
     ) -> anyhow::Result<Router> {
         Ok(router)
     }
 
-    fn after_middleware(
-        &self,
-        router: Router,
-        _context: &AppContext,
-        _state: &S,
-    ) -> anyhow::Result<Router> {
+    fn after_middleware(&self, router: Router, _context: &AppContext<S>) -> anyhow::Result<Router> {
         Ok(router)
     }
 
-    fn before_serve(
-        &self,
-        router: Router,
-        _context: &AppContext,
-        _state: &S,
-    ) -> anyhow::Result<Router> {
+    fn before_serve(&self, router: Router, _context: &AppContext<S>) -> anyhow::Result<Router> {
         Ok(router)
     }
 }

--- a/src/service/http/initializer/normalize_path.rs
+++ b/src/service/http/initializer/normalize_path.rs
@@ -16,7 +16,7 @@ impl<S> Initializer<S> for NormalizePathInitializer {
         "normalize-path".to_string()
     }
 
-    fn enabled(&self, context: &AppContext, _state: &S) -> bool {
+    fn enabled(&self, context: &AppContext<S>) -> bool {
         context
             .config()
             .service
@@ -28,7 +28,7 @@ impl<S> Initializer<S> for NormalizePathInitializer {
             .enabled(context)
     }
 
-    fn priority(&self, context: &AppContext, _state: &S) -> i32 {
+    fn priority(&self, context: &AppContext<S>) -> i32 {
         context
             .config()
             .service
@@ -40,12 +40,7 @@ impl<S> Initializer<S> for NormalizePathInitializer {
             .priority
     }
 
-    fn before_serve(
-        &self,
-        router: Router,
-        _context: &AppContext,
-        _state: &S,
-    ) -> anyhow::Result<Router> {
+    fn before_serve(&self, router: Router, _context: &AppContext<S>) -> anyhow::Result<Router> {
         let router = NormalizePathLayer::trim_trailing_slash().layer(router);
         let router = Router::new().nest_service("/", router);
         Ok(router)

--- a/src/service/http/middleware/catch_panic.rs
+++ b/src/service/http/middleware/catch_panic.rs
@@ -14,7 +14,7 @@ impl<S> Middleware<S> for CatchPanicMiddleware {
         "catch-panic".to_string()
     }
 
-    fn enabled(&self, context: &AppContext, _state: &S) -> bool {
+    fn enabled(&self, context: &AppContext<S>) -> bool {
         context
             .config()
             .service
@@ -26,7 +26,7 @@ impl<S> Middleware<S> for CatchPanicMiddleware {
             .enabled(context)
     }
 
-    fn priority(&self, context: &AppContext, _state: &S) -> i32 {
+    fn priority(&self, context: &AppContext<S>) -> i32 {
         context
             .config()
             .service
@@ -38,7 +38,7 @@ impl<S> Middleware<S> for CatchPanicMiddleware {
             .priority
     }
 
-    fn install(&self, router: Router, _context: &AppContext, _state: &S) -> anyhow::Result<Router> {
+    fn install(&self, router: Router, _context: &AppContext<S>) -> anyhow::Result<Router> {
         let router = router.layer(CatchPanicLayer::new());
 
         Ok(router)

--- a/src/service/http/middleware/compression.rs
+++ b/src/service/http/middleware/compression.rs
@@ -20,7 +20,7 @@ impl<S> Middleware<S> for ResponseCompressionMiddleware {
         "response-compression".to_string()
     }
 
-    fn enabled(&self, context: &AppContext, _state: &S) -> bool {
+    fn enabled(&self, context: &AppContext<S>) -> bool {
         context
             .config()
             .service
@@ -32,7 +32,7 @@ impl<S> Middleware<S> for ResponseCompressionMiddleware {
             .enabled(context)
     }
 
-    fn priority(&self, context: &AppContext, _state: &S) -> i32 {
+    fn priority(&self, context: &AppContext<S>) -> i32 {
         context
             .config()
             .service
@@ -44,7 +44,7 @@ impl<S> Middleware<S> for ResponseCompressionMiddleware {
             .priority
     }
 
-    fn install(&self, router: Router, _context: &AppContext, _state: &S) -> anyhow::Result<Router> {
+    fn install(&self, router: Router, _context: &AppContext<S>) -> anyhow::Result<Router> {
         let router = router.layer(CompressionLayer::new());
 
         Ok(router)
@@ -57,7 +57,7 @@ impl<S> Middleware<S> for RequestDecompressionMiddleware {
         "request-decompression".to_string()
     }
 
-    fn enabled(&self, context: &AppContext, _state: &S) -> bool {
+    fn enabled(&self, context: &AppContext<S>) -> bool {
         context
             .config()
             .service
@@ -69,7 +69,7 @@ impl<S> Middleware<S> for RequestDecompressionMiddleware {
             .enabled(context)
     }
 
-    fn priority(&self, context: &AppContext, _state: &S) -> i32 {
+    fn priority(&self, context: &AppContext<S>) -> i32 {
         context
             .config()
             .service
@@ -81,7 +81,7 @@ impl<S> Middleware<S> for RequestDecompressionMiddleware {
             .priority
     }
 
-    fn install(&self, router: Router, _context: &AppContext, _state: &S) -> anyhow::Result<Router> {
+    fn install(&self, router: Router, _context: &AppContext<S>) -> anyhow::Result<Router> {
         let router = router.layer(RequestDecompressionLayer::new());
 
         Ok(router)

--- a/src/service/http/middleware/default.rs
+++ b/src/service/http/middleware/default.rs
@@ -13,10 +13,7 @@ use crate::service::http::middleware::tracing::TracingMiddleware;
 use crate::service::http::middleware::Middleware;
 use std::collections::BTreeMap;
 
-pub fn default_middleware<S>(
-    context: &AppContext,
-    state: &S,
-) -> BTreeMap<String, Box<dyn Middleware<S>>> {
+pub fn default_middleware<S>(context: &AppContext<S>) -> BTreeMap<String, Box<dyn Middleware<S>>> {
     let middleware: Vec<Box<dyn Middleware<S>>> = vec![
         Box::new(SensitiveRequestHeadersMiddleware),
         Box::new(SensitiveResponseHeadersMiddleware),
@@ -30,7 +27,7 @@ pub fn default_middleware<S>(
     ];
     middleware
         .into_iter()
-        .filter(|middleware| middleware.enabled(context, state))
+        .filter(|middleware| middleware.enabled(context))
         .map(|middleware| (middleware.name(), middleware))
         .collect()
 }

--- a/src/service/http/middleware/mod.rs
+++ b/src/service/http/middleware/mod.rs
@@ -24,7 +24,7 @@ use axum::Router;
 ///        is done automatically by Roadster based on [Middleware::priority]).
 pub trait Middleware<S>: Send {
     fn name(&self) -> String;
-    fn enabled(&self, context: &AppContext, state: &S) -> bool;
+    fn enabled(&self, context: &AppContext<S>) -> bool;
     /// Used to determine the order in which the middleware will run when handling a request. Smaller
     /// numbers will run before larger numbers. For example, a middleware with priority `-10`
     /// will run before a middleware with priority `10`.
@@ -41,6 +41,6 @@ pub trait Middleware<S>: Send {
     /// is done automatically by Roadster based on [Middleware::priority]). So, a middleware
     /// with priority `-10` will be _installed after_ a middleware with priority `10`, which will
     /// allow the middleware with priority `-10` to _run before_ a middleware with priority `10`.
-    fn priority(&self, context: &AppContext, state: &S) -> i32;
-    fn install(&self, router: Router, context: &AppContext, state: &S) -> anyhow::Result<Router>;
+    fn priority(&self, context: &AppContext<S>) -> i32;
+    fn install(&self, router: Router, context: &AppContext<S>) -> anyhow::Result<Router>;
 }

--- a/src/service/http/middleware/request_id.rs
+++ b/src/service/http/middleware/request_id.rs
@@ -42,7 +42,7 @@ impl<S> Middleware<S> for SetRequestIdMiddleware {
         "set-request-id".to_string()
     }
 
-    fn enabled(&self, context: &AppContext, _state: &S) -> bool {
+    fn enabled(&self, context: &AppContext<S>) -> bool {
         context
             .config()
             .service
@@ -54,7 +54,7 @@ impl<S> Middleware<S> for SetRequestIdMiddleware {
             .enabled(context)
     }
 
-    fn priority(&self, context: &AppContext, _state: &S) -> i32 {
+    fn priority(&self, context: &AppContext<S>) -> i32 {
         context
             .config()
             .service
@@ -66,7 +66,7 @@ impl<S> Middleware<S> for SetRequestIdMiddleware {
             .priority
     }
 
-    fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
+    fn install(&self, router: Router, context: &AppContext<S>) -> anyhow::Result<Router> {
         let header_name = &context
             .config()
             .service
@@ -93,7 +93,7 @@ impl<S> Middleware<S> for PropagateRequestIdMiddleware {
         "propagate-request-id".to_string()
     }
 
-    fn enabled(&self, context: &AppContext, _state: &S) -> bool {
+    fn enabled(&self, context: &AppContext<S>) -> bool {
         context
             .config()
             .service
@@ -105,7 +105,7 @@ impl<S> Middleware<S> for PropagateRequestIdMiddleware {
             .enabled(context)
     }
 
-    fn priority(&self, context: &AppContext, _state: &S) -> i32 {
+    fn priority(&self, context: &AppContext<S>) -> i32 {
         context
             .config()
             .service
@@ -117,7 +117,7 @@ impl<S> Middleware<S> for PropagateRequestIdMiddleware {
             .priority
     }
 
-    fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
+    fn install(&self, router: Router, context: &AppContext<S>) -> anyhow::Result<Router> {
         let header_name = &context
             .config()
             .service

--- a/src/service/http/middleware/sensitive_headers.rs
+++ b/src/service/http/middleware/sensitive_headers.rs
@@ -61,7 +61,7 @@ impl<S> Middleware<S> for SensitiveRequestHeadersMiddleware {
         "sensitive-request-headers".to_string()
     }
 
-    fn enabled(&self, context: &AppContext, _state: &S) -> bool {
+    fn enabled(&self, context: &AppContext<S>) -> bool {
         context
             .config()
             .service
@@ -73,7 +73,7 @@ impl<S> Middleware<S> for SensitiveRequestHeadersMiddleware {
             .enabled(context)
     }
 
-    fn priority(&self, context: &AppContext, _state: &S) -> i32 {
+    fn priority(&self, context: &AppContext<S>) -> i32 {
         context
             .config()
             .service
@@ -84,7 +84,7 @@ impl<S> Middleware<S> for SensitiveRequestHeadersMiddleware {
             .common
             .priority
     }
-    fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
+    fn install(&self, router: Router, context: &AppContext<S>) -> anyhow::Result<Router> {
         let headers = context
             .config()
             .service
@@ -109,7 +109,7 @@ impl<S> Middleware<S> for SensitiveResponseHeadersMiddleware {
         "sensitive-response-headers".to_string()
     }
 
-    fn enabled(&self, context: &AppContext, _state: &S) -> bool {
+    fn enabled(&self, context: &AppContext<S>) -> bool {
         context
             .config()
             .service
@@ -121,7 +121,7 @@ impl<S> Middleware<S> for SensitiveResponseHeadersMiddleware {
             .enabled(context)
     }
 
-    fn priority(&self, context: &AppContext, _state: &S) -> i32 {
+    fn priority(&self, context: &AppContext<S>) -> i32 {
         context
             .config()
             .service
@@ -132,7 +132,7 @@ impl<S> Middleware<S> for SensitiveResponseHeadersMiddleware {
             .common
             .priority
     }
-    fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
+    fn install(&self, router: Router, context: &AppContext<S>) -> anyhow::Result<Router> {
         let headers = context
             .config()
             .service

--- a/src/service/http/middleware/size_limit.rs
+++ b/src/service/http/middleware/size_limit.rs
@@ -28,7 +28,7 @@ impl<S> Middleware<S> for RequestBodyLimitMiddleware {
         "request-body-size-limit".to_string()
     }
 
-    fn enabled(&self, context: &AppContext, _state: &S) -> bool {
+    fn enabled(&self, context: &AppContext<S>) -> bool {
         context
             .config()
             .service
@@ -40,7 +40,7 @@ impl<S> Middleware<S> for RequestBodyLimitMiddleware {
             .enabled(context)
     }
 
-    fn priority(&self, context: &AppContext, _state: &S) -> i32 {
+    fn priority(&self, context: &AppContext<S>) -> i32 {
         context
             .config()
             .service
@@ -52,7 +52,7 @@ impl<S> Middleware<S> for RequestBodyLimitMiddleware {
             .priority
     }
 
-    fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
+    fn install(&self, router: Router, context: &AppContext<S>) -> anyhow::Result<Router> {
         let limit = &context
             .config()
             .service

--- a/src/service/http/middleware/timeout.rs
+++ b/src/service/http/middleware/timeout.rs
@@ -28,7 +28,7 @@ impl<S> Middleware<S> for TimeoutMiddleware {
         "timeout".to_string()
     }
 
-    fn enabled(&self, context: &AppContext, _state: &S) -> bool {
+    fn enabled(&self, context: &AppContext<S>) -> bool {
         context
             .config()
             .service
@@ -40,7 +40,7 @@ impl<S> Middleware<S> for TimeoutMiddleware {
             .enabled(context)
     }
 
-    fn priority(&self, context: &AppContext, _state: &S) -> i32 {
+    fn priority(&self, context: &AppContext<S>) -> i32 {
         context
             .config()
             .service
@@ -52,7 +52,7 @@ impl<S> Middleware<S> for TimeoutMiddleware {
             .priority
     }
 
-    fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
+    fn install(&self, router: Router, context: &AppContext<S>) -> anyhow::Result<Router> {
         let timeout = &context
             .config()
             .service

--- a/src/service/http/middleware/tracing.rs
+++ b/src/service/http/middleware/tracing.rs
@@ -21,7 +21,7 @@ impl<S> Middleware<S> for TracingMiddleware {
         "tracing".to_string()
     }
 
-    fn enabled(&self, context: &AppContext, _state: &S) -> bool {
+    fn enabled(&self, context: &AppContext<S>) -> bool {
         context
             .config()
             .service
@@ -33,7 +33,7 @@ impl<S> Middleware<S> for TracingMiddleware {
             .enabled(context)
     }
 
-    fn priority(&self, context: &AppContext, _state: &S) -> i32 {
+    fn priority(&self, context: &AppContext<S>) -> i32 {
         context
             .config()
             .service
@@ -45,7 +45,7 @@ impl<S> Middleware<S> for TracingMiddleware {
             .priority
     }
 
-    fn install(&self, router: Router, context: &AppContext, _state: &S) -> anyhow::Result<Router> {
+    fn install(&self, router: Router, context: &AppContext<S>) -> anyhow::Result<Router> {
         let request_id_header_name = &context
             .config()
             .service

--- a/src/service/http/service.rs
+++ b/src/service/http/service.rs
@@ -18,6 +18,7 @@ use std::fs::File;
 use std::io::Write;
 #[cfg(feature = "open-api")]
 use std::path::PathBuf;
+#[cfg(feature = "open-api")]
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -34,7 +35,7 @@ impl<A: App> AppService<A> for HttpService {
         "http".to_string()
     }
 
-    fn enabled(context: &AppContext, _state: &A::State) -> bool {
+    fn enabled(context: &AppContext<A::State>) -> bool {
         context.config().service.http.common.enabled(context)
     }
 
@@ -43,8 +44,7 @@ impl<A: App> AppService<A> for HttpService {
         &self,
         roadster_cli: &RoadsterCli,
         _app_cli: &A::Cli,
-        _app_context: &AppContext,
-        _app_state: &A::State,
+        _app_context: &AppContext<A::State>,
     ) -> anyhow::Result<bool> {
         if let Some(command) = roadster_cli.command.as_ref() {
             match command {
@@ -68,8 +68,7 @@ impl<A: App> AppService<A> for HttpService {
 
     async fn run(
         &self,
-        app_context: Arc<AppContext>,
-        _app_state: Arc<A::State>,
+        app_context: AppContext<A::State>,
         cancel_token: CancellationToken,
     ) -> anyhow::Result<()> {
         let server_addr = app_context.config().service.http.custom.address.url();
@@ -88,10 +87,9 @@ impl HttpService {
     /// Create a new [HttpServiceBuilder].
     pub fn builder<A: App>(
         path_root: &str,
-        context: &AppContext,
-        state: &A::State,
+        context: &AppContext<A::State>,
     ) -> HttpServiceBuilder<A> {
-        HttpServiceBuilder::new(path_root, context, state)
+        HttpServiceBuilder::new(path_root, context)
     }
 
     /// List the available HTTP API routes.

--- a/src/service/worker/sidekiq/roadster_worker.rs
+++ b/src/service/worker/sidekiq/roadster_worker.rs
@@ -5,9 +5,9 @@ use crate::service::worker::sidekiq::app_worker::AppWorkerConfig;
 use async_trait::async_trait;
 use serde::Serialize;
 
+use crate::app_context::AppContext;
 use sidekiq::{RedisPool, Worker, WorkerOpts};
 use std::marker::PhantomData;
-use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, instrument};
 
@@ -32,8 +32,8 @@ where
     Args: Send + Sync + Serialize,
     W: AppWorker<A, Args>,
 {
-    pub(crate) fn new(inner: W, state: Arc<A::State>) -> Self {
-        let config = inner.config(&state);
+    pub(crate) fn new(inner: W, context: &AppContext<A::State>) -> Self {
+        let config = inner.config(context);
         Self {
             inner,
             inner_config: config,


### PR DESCRIPTION
Add the app's custom state as a member of the `AppContext` this has several benefits:

- Only need to pass the `AppContext` as a parameter to methods, instead of separate methods for the `AppContext` and the custom state. This reduces boilerplate and simplfies many method defs.
- We can ensure the custom state can be cheaply cloned by wrapping in an `Arc` inside the `AppContext`.
- We no longer require the consumer to implement an `Into<AppContext>` (or similar) trait.