### PR TITLE
Set up mocking using `mockall` crate

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,7 @@
+[test-groups]
+# Mocks of static methods need to run sequentially. This test group is for tests that mock AppService's static methods.
+app-service-static-mock = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'test(service::registry::tests::)'
+test-group = "app-service-static-mock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,9 +87,14 @@ const_format = "0.2.32"
 typed-builder = "0.18.2"
 num-traits = "0.2.19"
 log = "0.4.21"
+mockall_double = "0.3.1"
 
 [dev-dependencies]
 cargo-husky = { version = "1.5.0", default-features = false, features = ["user-hooks"] }
+mockall = "0.12.1"
+rstest = "0.19.0"
+# Required by rstest (rstest doesn't support tokio)
+async-std = { version = "1.12.0", features = ["attributes"] }
 
 [workspace]
 members = [".", "examples/*"]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,7 @@ Code coverage stats are generated automatically in CI. To generate coverage stat
 
 ```shell
 # Install coverage dependencies
-cargo binstall grcov
+cargo binstall cargo-llvm-cov
 rustup component add llvm-tools
 # If you have Nix on you system, you can install the `genhtml` command using the nix package.
 # Todo: other methods of installing `genhtml`

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -5,6 +5,7 @@ use sea_orm_migration::MigratorTrait;
 use tracing::warn;
 
 use crate::app::App;
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::cli::{RoadsterCli, RunRoadsterCommand};
 

--- a/src/cli/print_config.rs
+++ b/src/cli/print_config.rs
@@ -5,6 +5,7 @@ use strum_macros::{EnumString, IntoStaticStr};
 use tracing::info;
 
 use crate::app::App;
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::cli::{RoadsterCli, RunRoadsterCommand};
 

--- a/src/config/service/http/initializer.rs
+++ b/src/config/service/http/initializer.rs
@@ -1,3 +1,4 @@
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::config::app_config::CustomConfig;
 use crate::service::http::initializer::normalize_path::NormalizePathConfig;

--- a/src/config/service/http/middleware.rs
+++ b/src/config/service/http/middleware.rs
@@ -1,3 +1,4 @@
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::config::app_config::CustomConfig;
 use crate::service::http::middleware::catch_panic::CatchPanicConfig;

--- a/src/config/service/mod.rs
+++ b/src/config/service/mod.rs
@@ -1,6 +1,7 @@
 pub mod http;
 pub mod worker;
 
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::config::service::http::HttpServiceConfig;
 #[cfg(feature = "sidekiq")]

--- a/src/controller/health.rs
+++ b/src/controller/health.rs
@@ -29,6 +29,7 @@ use sidekiq::redis_rs::cmd;
 use tokio::time::timeout;
 use tracing::instrument;
 
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::controller::build_path;
 use crate::view::app_error::AppError;

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -4,6 +4,7 @@ use aide::axum::ApiRouter;
 use axum::Router;
 use itertools::Itertools;
 
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::config::app_config::AppConfig;
 

--- a/src/service/http/builder.rs
+++ b/src/service/http/builder.rs
@@ -1,4 +1,5 @@
 use crate::app::App;
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::controller::default_routes;
 use crate::service::http::initializer::default::default_initializers;
@@ -25,7 +26,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use tracing::info;
 
-pub struct HttpServiceBuilder<A: App> {
+pub struct HttpServiceBuilder<A: App + 'static> {
     #[cfg(not(feature = "open-api"))]
     router: Router<AppContext<A::State>>,
     #[cfg(feature = "open-api")]

--- a/src/service/http/initializer/default.rs
+++ b/src/service/http/initializer/default.rs
@@ -1,3 +1,4 @@
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::initializer::normalize_path::NormalizePathInitializer;
 use crate::service::http::initializer::Initializer;

--- a/src/service/http/initializer/mod.rs
+++ b/src/service/http/initializer/mod.rs
@@ -1,6 +1,7 @@
 pub mod default;
 pub mod normalize_path;
 
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use axum::Router;
 

--- a/src/service/http/initializer/normalize_path.rs
+++ b/src/service/http/initializer/normalize_path.rs
@@ -1,3 +1,4 @@
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::initializer::Initializer;
 use axum::Router;

--- a/src/service/http/middleware/catch_panic.rs
+++ b/src/service/http/middleware/catch_panic.rs
@@ -1,3 +1,4 @@
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::Middleware;
 use axum::Router;

--- a/src/service/http/middleware/compression.rs
+++ b/src/service/http/middleware/compression.rs
@@ -1,3 +1,4 @@
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::Middleware;
 use axum::Router;

--- a/src/service/http/middleware/default.rs
+++ b/src/service/http/middleware/default.rs
@@ -1,3 +1,4 @@
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::catch_panic::CatchPanicMiddleware;
 use crate::service::http::middleware::compression::RequestDecompressionMiddleware;

--- a/src/service/http/middleware/mod.rs
+++ b/src/service/http/middleware/mod.rs
@@ -7,6 +7,7 @@ pub mod size_limit;
 pub mod timeout;
 pub mod tracing;
 
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use axum::Router;
 

--- a/src/service/http/middleware/request_id.rs
+++ b/src/service/http/middleware/request_id.rs
@@ -1,3 +1,4 @@
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::Middleware;
 use axum::http::HeaderName;

--- a/src/service/http/middleware/sensitive_headers.rs
+++ b/src/service/http/middleware/sensitive_headers.rs
@@ -1,3 +1,4 @@
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::Middleware;
 use axum::http::{header, HeaderName};

--- a/src/service/http/middleware/size_limit.rs
+++ b/src/service/http/middleware/size_limit.rs
@@ -1,3 +1,4 @@
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::Middleware;
 use anyhow::bail;

--- a/src/service/http/middleware/timeout.rs
+++ b/src/service/http/middleware/timeout.rs
@@ -1,3 +1,4 @@
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::Middleware;
 use axum::Router;

--- a/src/service/http/middleware/tracing.rs
+++ b/src/service/http/middleware/tracing.rs
@@ -1,3 +1,4 @@
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::Middleware;
 use axum::extract::MatchedPath;

--- a/src/service/http/service.rs
+++ b/src/service/http/service.rs
@@ -1,4 +1,5 @@
 use crate::app::App;
+#[mockall_double::double]
 use crate::app_context::AppContext;
 #[cfg(all(feature = "cli", feature = "open-api"))]
 use crate::cli::RoadsterSubCommand;
@@ -30,7 +31,7 @@ pub struct HttpService {
 }
 
 #[async_trait]
-impl<A: App> AppService<A> for HttpService {
+impl<A: App + 'static> AppService<A> for HttpService {
     fn name() -> String {
         "http".to_string()
     }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,4 +1,5 @@
 use crate::app::App;
+#[mockall_double::double]
 use crate::app_context::AppContext;
 #[cfg(feature = "cli")]
 use crate::cli::RoadsterCli;
@@ -13,7 +14,8 @@ pub mod worker;
 /// include, but are not limited to: an [http API][crate::service::http::service::HttpService],
 /// a sidekiq processor, or a gRPC API.
 #[async_trait]
-pub trait AppService<A: App>: Send + Sync {
+#[cfg_attr(test, mockall::automock)]
+pub trait AppService<A: App + 'static>: Send + Sync {
     /// The name of the service.
     fn name() -> String
     where
@@ -58,9 +60,10 @@ pub trait AppService<A: App>: Send + Sync {
 /// in which case the [ServiceRegistry][crate::service::registry::ServiceRegistry] will only
 /// build and register the service if [AppService::enabled] is `true`.
 #[async_trait]
+#[cfg_attr(test, mockall::automock)]
 pub trait AppServiceBuilder<A, S>
 where
-    A: App,
+    A: App + 'static,
     S: AppService<A>,
 {
     fn enabled(&self, app_context: &AppContext<A::State>) -> bool {

--- a/src/service/worker/sidekiq/app_worker.rs
+++ b/src/service/worker/sidekiq/app_worker.rs
@@ -1,4 +1,5 @@
 use crate::app::App;
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use async_trait::async_trait;
 use serde_derive::{Deserialize, Serialize};

--- a/src/service/worker/sidekiq/builder.rs
+++ b/src/service/worker/sidekiq/builder.rs
@@ -1,4 +1,5 @@
 use crate::app::App;
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::config::service::worker::sidekiq::StaleCleanUpBehavior;
 use crate::service::worker::sidekiq::app_worker::AppWorker;
@@ -18,7 +19,7 @@ const PERIODIC_KEY: &str = "periodic";
 
 pub struct SidekiqWorkerServiceBuilder<A>
 where
-    A: App,
+    A: App + 'static,
 {
     state: BuilderState<A>,
 }
@@ -36,7 +37,7 @@ enum BuilderState<A: App> {
 #[async_trait]
 impl<A> AppServiceBuilder<A, SidekiqWorkerService> for SidekiqWorkerServiceBuilder<A>
 where
-    A: App + 'static,
+    A: App,
 {
     fn enabled(&self, app_context: &AppContext<A::State>) -> bool {
         match self.state {

--- a/src/service/worker/sidekiq/roadster_worker.rs
+++ b/src/service/worker/sidekiq/roadster_worker.rs
@@ -1,11 +1,10 @@
 use crate::app::App;
-
+#[mockall_double::double]
+use crate::app_context::AppContext;
 use crate::service::worker::sidekiq::app_worker::AppWorker;
 use crate::service::worker::sidekiq::app_worker::AppWorkerConfig;
 use async_trait::async_trait;
 use serde::Serialize;
-
-use crate::app_context::AppContext;
 use sidekiq::{RedisPool, Worker, WorkerOpts};
 use std::marker::PhantomData;
 use std::time::Duration;

--- a/src/service/worker/sidekiq/service.rs
+++ b/src/service/worker/sidekiq/service.rs
@@ -1,4 +1,5 @@
 use crate::app::App;
+#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::worker::sidekiq::builder::SidekiqWorkerServiceBuilder;
 use crate::service::AppService;
@@ -13,7 +14,7 @@ pub struct SidekiqWorkerService {
 }
 
 #[async_trait]
-impl<A: App> AppService<A> for SidekiqWorkerService {
+impl<A: App + 'static> AppService<A> for SidekiqWorkerService {
     fn name() -> String
     where
         Self: Sized,


### PR DESCRIPTION
Create general mocks to use throughout Roadster for the `AppContext` and the `App` trait and its associated types.

Use the new mocks to write tests for the `ServiceRegistry`. Also needed to create mocks for the `AppService` and `AppServiceBuilder` traits.

https://github.com/roadster-rs/roadster/issues/99