### PR TITLE
Use Tokio for rstest tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,8 +93,6 @@ mockall_double = "0.3.1"
 cargo-husky = { version = "1.5.0", default-features = false, features = ["user-hooks"] }
 mockall = "0.12.1"
 rstest = "0.19.0"
-# Required by rstest (rstest doesn't support tokio)
-async-std = { version = "1.12.0", features = ["attributes"] }
 
 [workspace]
 members = [".", "examples/*"]

--- a/src/service/registry.rs
+++ b/src/service/registry.rs
@@ -78,6 +78,7 @@ mod tests {
     #[rstest]
     #[case(true, 1)]
     #[case(false, 0)]
+    #[tokio::test]
     fn register_service(#[case] service_enabled: bool, #[case] expected_count: usize) {
         // Arrange
         let mut context = MockAppContext::default();
@@ -103,6 +104,7 @@ mod tests {
     #[case(false, true, 0)]
     #[case(true, false, 0)]
     #[case(false, false, 0)]
+    #[tokio::test]
     async fn register_builder(
         #[case] service_enabled: bool,
         #[case] builder_enabled: bool,

--- a/src/service/registry.rs
+++ b/src/service/registry.rs
@@ -78,7 +78,6 @@ mod tests {
     #[rstest]
     #[case(true, 1)]
     #[case(false, 0)]
-    #[tokio::test]
     fn register_service(#[case] service_enabled: bool, #[case] expected_count: usize) {
         // Arrange
         let mut context = MockAppContext::default();


### PR DESCRIPTION
Rstest can use Tokyo as long as the annotation comes at the end.