### PR TITLE
Update dependencies that can be updated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ dotenvy = "0.15.7"
 # Tracing
 tracing = { version = "0.1.40", features = ["async-await"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-opentelemetry-semantic-conventions = "0.14.0"
+opentelemetry-semantic-conventions = "0.15.0"
 opentelemetry = { version = "0.22.0", features = ["trace", "metrics", "logs"], optional = true }
 opentelemetry_sdk = { version = "0.22.1", features = ["tokio", "rt-tokio", "metrics", "logs", "trace"], optional = true }
 opentelemetry-otlp = { version = "0.15.0", features = ["metrics", "trace", "logs"], optional = true }
@@ -73,13 +73,13 @@ jsonwebtoken = { version = "9.3.0", optional = true }
 clap = { version = "4.5.4", features = ["derive", "string"], optional = true }
 
 # Others
-anyhow = "1.0.83"
+anyhow = "1.0.84"
 serde = "1.0.202"
 serde_derive = "1.0.202"
 serde_with = { version = "3.8.1", features = ["macros", "chrono_0_4"] }
 strum = "0.26.2"
 strum_macros = "0.26.2"
-itertools = "0.12.1"
+itertools = "0.13.0"
 serde_json = "1.0.117"
 toml = "0.8.13"
 url = { version = "2.5.0", features = ["serde"] }

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 roadster = { version = "0.1", path = "../.." }
 tokio = { version = "1.37.0", features = ["full", "macros"] }
-anyhow = "1.0.83"
+anyhow = "1.0.84"
 tracing = { version = "0.1.40", features = ["async-await"] }
 async-trait = "0.1.80"
 aide = { version = "0.13.4", features = ["axum"] }


### PR DESCRIPTION
The otel dependencies that have available updates have breaking changes that I haven't figured out how to resolve yet -- they don't seem to be documented well.