### PR TITLE
Use automock to mock traits instead of the mock! macro

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -86,6 +86,7 @@ where
     Ok(())
 }
 
+#[cfg_attr(test, mockall::automock(type State = (); type Cli = MockCli; type M = MockMigrator;))]
 #[async_trait]
 pub trait App: Send + Sync {
     // Todo: Are clone, etc necessary if we store it inside an Arc?
@@ -155,20 +156,5 @@ mockall::mock! {
     #[async_trait]
     impl MigratorTrait for Migrator {
         fn migrations() -> Vec<Box<dyn MigrationTrait>>;
-    }
-}
-
-#[cfg(test)]
-mockall::mock! {
-    pub TestApp {}
-    #[async_trait]
-    impl App for TestApp {
-        type State = ();
-        #[cfg(feature = "cli")]
-        type Cli = MockCli;
-        #[cfg(feature = "db-sql")]
-        type M = MockMigrator;
-
-        async fn with_state(context: &AppContext<()>) -> anyhow::Result<<MockTestApp as App>::State>;
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,6 @@
 use crate::app::App;
 #[cfg(test)]
-use crate::app::MockTestApp;
+use crate::app::MockApp;
 #[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::cli::roadster::{RoadsterCli, RunRoadsterCommand};
@@ -101,12 +101,12 @@ mockall::mock! {
     pub Cli {}
 
     #[async_trait]
-    impl RunCommand<MockTestApp> for Cli {
+    impl RunCommand<MockApp> for Cli {
         async fn run(
                 &self,
-                app: &MockTestApp,
-                cli: &<MockTestApp as App>::Cli,
-                context: &AppContext<<MockTestApp as App>::State>,
+                app: &MockApp,
+                cli: &<MockApp as App>::Cli,
+                context: &AppContext<<MockApp as App>::State>,
             ) -> anyhow::Result<bool>;
     }
 
@@ -170,7 +170,7 @@ mod tests {
             .collect_vec();
 
         // Act
-        let (roadster_cli, _a) = super::parse_cli::<MockTestApp, _, _>(args).unwrap();
+        let (roadster_cli, _a) = super::parse_cli::<MockApp, _, _>(args).unwrap();
 
         // Assert
         assert_toml_snapshot!(roadster_cli);

--- a/src/controller/http/docs.rs
+++ b/src/controller/http/docs.rs
@@ -146,7 +146,7 @@ fn api_schema_route<S>(context: &AppContext<S>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::MockTestApp;
+    use crate::app::MockApp;
     use crate::app_context::MockAppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
@@ -176,7 +176,7 @@ mod tests {
             .scalar
             .route
             .clone_from(&route);
-        let mut context = MockAppContext::<MockTestApp>::default();
+        let mut context = MockAppContext::<MockApp>::default();
         context.expect_config().return_const(config);
 
         assert_eq!(scalar_enabled(&context), enabled);
@@ -209,7 +209,7 @@ mod tests {
             .redoc
             .route
             .clone_from(&route);
-        let mut context = MockAppContext::<MockTestApp>::default();
+        let mut context = MockAppContext::<MockApp>::default();
         context.expect_config().return_const(config);
 
         assert_eq!(redoc_enabled(&context), enabled);
@@ -242,7 +242,7 @@ mod tests {
             .api_schema
             .route
             .clone_from(&route);
-        let mut context = MockAppContext::<MockTestApp>::default();
+        let mut context = MockAppContext::<MockApp>::default();
         context.expect_config().return_const(config);
 
         assert_eq!(api_schema_enabled(&context), enabled);

--- a/src/controller/http/health.rs
+++ b/src/controller/http/health.rs
@@ -249,7 +249,7 @@ fn health_get_docs(op: TransformOperation) -> TransformOperation {
 
 #[cfg(test)]
 mod tests {
-    use crate::app::MockTestApp;
+    use crate::app::MockApp;
     use crate::app_context::MockAppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
@@ -279,7 +279,7 @@ mod tests {
             .health
             .route
             .clone_from(&route);
-        let mut context = MockAppContext::<MockTestApp>::default();
+        let mut context = MockAppContext::<MockApp>::default();
         context.expect_config().return_const(config);
 
         assert_eq!(super::enabled(&context), enabled);

--- a/src/controller/http/ping.rs
+++ b/src/controller/http/ping.rs
@@ -88,7 +88,7 @@ fn ping_get_docs(op: TransformOperation) -> TransformOperation {
 
 #[cfg(test)]
 mod tests {
-    use crate::app::MockTestApp;
+    use crate::app::MockApp;
     use crate::app_context::MockAppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
@@ -118,7 +118,7 @@ mod tests {
             .ping
             .route
             .clone_from(&route);
-        let mut context = MockAppContext::<MockTestApp>::default();
+        let mut context = MockAppContext::<MockApp>::default();
         context.expect_config().return_const(config);
 
         assert_eq!(super::enabled(&context), enabled);

--- a/src/service/http/builder.rs
+++ b/src/service/http/builder.rs
@@ -212,7 +212,7 @@ impl<A: App> AppServiceBuilder<A, HttpService> for HttpServiceBuilder<A> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::MockTestApp;
+    use crate::app::MockApp;
     use crate::app_context::MockAppContext;
     use crate::service::http::initializer::MockInitializer;
     use crate::service::http::middleware::MockMiddleware;
@@ -225,7 +225,7 @@ mod tests {
         context
             .expect_clone()
             .returning(MockAppContext::<()>::default);
-        let builder = HttpServiceBuilder::<MockTestApp>::empty(&context);
+        let builder = HttpServiceBuilder::<MockApp>::empty(&context);
 
         let mut middleware = MockMiddleware::default();
         middleware.expect_enabled().returning(|_| true);
@@ -247,7 +247,7 @@ mod tests {
         context
             .expect_clone()
             .returning(MockAppContext::<()>::default);
-        let builder = HttpServiceBuilder::<MockTestApp>::empty(&context);
+        let builder = HttpServiceBuilder::<MockApp>::empty(&context);
 
         let mut middleware = MockMiddleware::default();
         middleware.expect_enabled().returning(|_| false);
@@ -268,7 +268,7 @@ mod tests {
         context
             .expect_clone()
             .returning(MockAppContext::<()>::default);
-        let builder = HttpServiceBuilder::<MockTestApp>::empty(&context);
+        let builder = HttpServiceBuilder::<MockApp>::empty(&context);
 
         let mut middleware = MockMiddleware::default();
         middleware.expect_name().returning(|| "test".to_string());
@@ -289,7 +289,7 @@ mod tests {
         context
             .expect_clone()
             .returning(MockAppContext::<()>::default);
-        let builder = HttpServiceBuilder::<MockTestApp>::empty(&context);
+        let builder = HttpServiceBuilder::<MockApp>::empty(&context);
 
         let mut initializer = MockInitializer::default();
         initializer.expect_enabled().returning(|_| true);
@@ -311,7 +311,7 @@ mod tests {
         context
             .expect_clone()
             .returning(MockAppContext::<()>::default);
-        let builder = HttpServiceBuilder::<MockTestApp>::empty(&context);
+        let builder = HttpServiceBuilder::<MockApp>::empty(&context);
 
         let mut initializer = MockInitializer::default();
         initializer.expect_enabled().returning(|_| false);
@@ -332,7 +332,7 @@ mod tests {
         context
             .expect_clone()
             .returning(MockAppContext::<()>::default);
-        let builder = HttpServiceBuilder::<MockTestApp>::empty(&context);
+        let builder = HttpServiceBuilder::<MockApp>::empty(&context);
 
         let mut initializer = MockInitializer::default();
         initializer.expect_name().returning(|| "test".to_string());

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -79,7 +79,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::app::MockTestApp;
+    use crate::app::MockApp;
     use crate::app_context::MockAppContext;
     use crate::service::{AppServiceBuilder, MockAppService};
     use async_trait::async_trait;
@@ -87,12 +87,12 @@ mod tests {
 
     struct TestAppServiceBuilder;
     #[async_trait]
-    impl AppServiceBuilder<MockTestApp, MockAppService<MockTestApp>> for TestAppServiceBuilder {
+    impl AppServiceBuilder<MockApp, MockAppService<MockApp>> for TestAppServiceBuilder {
         #[cfg_attr(coverage_nightly, coverage(off))]
         async fn build(
             self,
             _context: &MockAppContext<()>,
-        ) -> anyhow::Result<MockAppService<MockTestApp>> {
+        ) -> anyhow::Result<MockAppService<MockApp>> {
             Ok(MockAppService::default())
         }
     }
@@ -106,7 +106,7 @@ mod tests {
         let mut context = MockAppContext::default();
         context.expect_clone().returning(MockAppContext::default);
 
-        let enabled_ctx = MockAppService::<MockTestApp>::enabled_context();
+        let enabled_ctx = MockAppService::<MockApp>::enabled_context();
         enabled_ctx.expect().returning(move |_| service_enabled);
 
         // Act

--- a/src/service/registry.rs
+++ b/src/service/registry.rs
@@ -70,7 +70,7 @@ impl<A: App> ServiceRegistry<A> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::MockTestApp;
+    use crate::app::MockApp;
     use crate::app_context::MockAppContext;
     use crate::service::{MockAppService, MockAppServiceBuilder};
     use rstest::rstest;
@@ -84,14 +84,14 @@ mod tests {
         let mut context = MockAppContext::default();
         context.expect_clone().returning(MockAppContext::default);
 
-        let service: MockAppService<MockTestApp> = MockAppService::default();
-        let enabled_ctx = MockAppService::<MockTestApp>::enabled_context();
+        let service: MockAppService<MockApp> = MockAppService::default();
+        let enabled_ctx = MockAppService::<MockApp>::enabled_context();
         enabled_ctx.expect().returning(move |_| service_enabled);
-        let name_ctx = MockAppService::<MockTestApp>::name_context();
+        let name_ctx = MockAppService::<MockApp>::name_context();
         name_ctx.expect().returning(|| "test".to_string());
 
         // Act
-        let mut subject: ServiceRegistry<MockTestApp> = ServiceRegistry::new(&context);
+        let mut subject: ServiceRegistry<MockApp> = ServiceRegistry::new(&context);
         subject.register_service(service).unwrap();
 
         // Assert
@@ -115,9 +115,9 @@ mod tests {
         let mut context = MockAppContext::default();
         context.expect_clone().returning(MockAppContext::default);
 
-        let enabled_ctx = MockAppService::<MockTestApp>::enabled_context();
+        let enabled_ctx = MockAppService::<MockApp>::enabled_context();
         enabled_ctx.expect().returning(move |_| service_enabled);
-        let name_ctx = MockAppService::<MockTestApp>::name_context();
+        let name_ctx = MockAppService::<MockApp>::name_context();
         name_ctx.expect().returning(|| "test".to_string());
 
         let mut builder = MockAppServiceBuilder::default();
@@ -131,7 +131,7 @@ mod tests {
         }
 
         // Act
-        let mut subject: ServiceRegistry<MockTestApp> = ServiceRegistry::new(&context);
+        let mut subject: ServiceRegistry<MockApp> = ServiceRegistry::new(&context);
         subject.register_builder(builder).await.unwrap();
 
         // Assert

--- a/src/service/worker/sidekiq/service.rs
+++ b/src/service/worker/sidekiq/service.rs
@@ -93,7 +93,7 @@ impl SidekiqWorkerService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::MockTestApp;
+    use crate::app::MockApp;
     use crate::app_context::MockAppContext;
     use crate::config::app_config::AppConfig;
     use bb8::Pool;
@@ -137,7 +137,7 @@ mod tests {
         context.expect_redis_fetch().return_const(pool);
 
         assert_eq!(
-            <SidekiqWorkerService as AppService<MockTestApp>>::enabled(&context),
+            <SidekiqWorkerService as AppService<MockApp>>::enabled(&context),
             expected_enabled
         );
     }


### PR DESCRIPTION
There were a couple places we were using `mock!` instead of `automock`. IIRC this was because `automock` wasn't working for `async_trait` traits; however, after reading the `mockall` docs, I found that `automock` needs to be placed _before_ `async_trait` in order for it to work. Also, specifically for the `App` trait, I just learned how to specify associated types with `automock`.

With this new knowledge, we can replace a couple manual `mock!` impls with `automock`.