### PR TITLE
Remove mock `AppContext` and use a concrete version in tests instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,6 @@ const_format = "0.2.32"
 typed-builder = "0.18.2"
 num-traits = "0.2.19"
 log = "0.4.21"
-mockall_double = "0.3.1"
 futures = "0.3.30"
 validator = { version = "0.18.1", features = ["derive"] }
 
@@ -100,6 +99,7 @@ validator = { version = "0.18.1", features = ["derive"] }
 cargo-husky = { version = "1.5.0", default-features = false, features = ["user-hooks"] }
 insta = { version = "1.39.0", features = ["toml"] }
 mockall = "0.12.1"
+mockall_double = "0.3.1"
 rstest = "0.19.0"
 
 [workspace]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 #[cfg(feature = "cli")]
 use crate::cli::parse_cli;
@@ -51,7 +50,7 @@ where
     #[cfg(not(test))]
     let context = AppContext::<()>::new::<A>(config).await?;
     #[cfg(test)]
-    let context = AppContext::<()>::default();
+    let context = AppContext::<()>::test(Some(config), None)?;
 
     let state = A::with_state(&context).await?;
     let context = context.with_custom(state);

--- a/src/app_context.rs
+++ b/src/app_context.rs
@@ -1,16 +1,17 @@
 use crate::app::App;
 use crate::config::app_config::AppConfig;
 #[cfg(feature = "db-sql")]
-use sea_orm::Database;
-#[cfg(feature = "db-sql")]
 use sea_orm::DatabaseConnection;
 use std::sync::Arc;
-#[cfg(feature = "sidekiq")]
-use tracing::info;
+
+#[cfg(not(test))]
+type Inner = AppContextInner;
+#[cfg(test)]
+type Inner = MockAppContextInner;
 
 #[derive(Clone)]
 pub struct AppContext<T = ()> {
-    inner: Arc<AppContextInner>,
+    inner: Arc<Inner>,
     custom: Arc<T>,
 }
 
@@ -23,54 +24,84 @@ impl<T> AppContext<T> {
     where
         A: App,
     {
-        #[cfg(feature = "db-sql")]
-        let db = Database::connect(A::db_connection_options(&config)?).await?;
+        #[cfg(test)]
+        // The `config.clone()` here is technically not necessary. However, without it, RustRover
+        // is giving a "value used after move" error when creating an actual `AppContext` below.
+        let context = { Self::test(Some(config.clone()), None)? };
 
-        #[cfg(feature = "sidekiq")]
-        let (redis_enqueue, redis_fetch) = {
-            let sidekiq_config = &config.service.sidekiq;
-            let redis_config = &sidekiq_config.custom.redis;
-            let redis = sidekiq::RedisConnectionManager::new(redis_config.uri.to_string())?;
-            let redis_enqueue = {
-                let pool = bb8::Pool::builder().min_idle(redis_config.enqueue_pool.min_idle);
-                let pool = redis_config
-                    .enqueue_pool
-                    .max_connections
-                    .iter()
-                    .fold(pool, |pool, max_conns| pool.max_size(*max_conns));
-                pool.build(redis.clone()).await?
-            };
-            let redis_fetch = if redis_config
-                .fetch_pool
-                .max_connections
-                .iter()
-                .any(|max_conns| *max_conns == 0)
-            {
-                info!(
-                "Redis fetch pool configured with size of zero, will not start the Sidekiq processor"
-            );
-                None
-            } else {
-                let pool = bb8::Pool::builder().min_idle(redis_config.fetch_pool.min_idle);
-                let pool = redis_config
+        #[cfg(not(test))]
+        let context = {
+            #[cfg(feature = "db-sql")]
+            let db = sea_orm::Database::connect(A::db_connection_options(&config)?).await?;
+
+            #[cfg(feature = "sidekiq")]
+            let (redis_enqueue, redis_fetch) = {
+                let sidekiq_config = &config.service.sidekiq;
+                let redis_config = &sidekiq_config.custom.redis;
+                let redis = sidekiq::RedisConnectionManager::new(redis_config.uri.to_string())?;
+                let redis_enqueue = {
+                    let pool = bb8::Pool::builder().min_idle(redis_config.enqueue_pool.min_idle);
+                    let pool = redis_config
+                        .enqueue_pool
+                        .max_connections
+                        .iter()
+                        .fold(pool, |pool, max_conns| pool.max_size(*max_conns));
+                    pool.build(redis.clone()).await?
+                };
+                let redis_fetch = if redis_config
                     .fetch_pool
                     .max_connections
                     .iter()
-                    .fold(pool, |pool, max_conns| pool.max_size(*max_conns));
-                Some(pool.build(redis.clone()).await?)
+                    .any(|max_conns| *max_conns == 0)
+                {
+                    tracing::info!("Redis fetch pool configured with size of zero, will not start the Sidekiq processor");
+                    None
+                } else {
+                    let pool = bb8::Pool::builder().min_idle(redis_config.fetch_pool.min_idle);
+                    let pool = redis_config
+                        .fetch_pool
+                        .max_connections
+                        .iter()
+                        .fold(pool, |pool, max_conns| pool.max_size(*max_conns));
+                    Some(pool.build(redis.clone()).await?)
+                };
+                (redis_enqueue, redis_fetch)
             };
-            (redis_enqueue, redis_fetch)
+            let inner = AppContextInner {
+                config,
+                #[cfg(feature = "db-sql")]
+                db,
+                #[cfg(feature = "sidekiq")]
+                redis_enqueue,
+                #[cfg(feature = "sidekiq")]
+                redis_fetch,
+            };
+            AppContext {
+                inner: Arc::new(inner),
+                custom: Arc::new(()),
+            }
         };
 
-        let inner = AppContextInner {
-            config,
-            #[cfg(feature = "db-sql")]
-            db,
-            #[cfg(feature = "sidekiq")]
-            redis_enqueue,
-            #[cfg(feature = "sidekiq")]
-            redis_fetch,
-        };
+        Ok(context)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test(
+        config: Option<AppConfig>,
+        #[cfg(not(feature = "sidekiq"))] _redis: Option<()>,
+        #[cfg(feature = "sidekiq")] redis: Option<sidekiq::RedisPool>,
+    ) -> anyhow::Result<AppContext<()>> {
+        let mut inner = MockAppContextInner::default();
+        inner
+            .expect_config()
+            .return_const(config.unwrap_or(AppConfig::test(None)?));
+        #[cfg(feature = "sidekiq")]
+        if let Some(redis) = redis {
+            inner.expect_redis_enqueue().return_const(redis.clone());
+            inner.expect_redis_fetch().return_const(Some(redis));
+        } else {
+            inner.expect_redis_fetch().return_const(None);
+        }
         Ok(AppContext {
             inner: Arc::new(inner),
             custom: Arc::new(()),
@@ -85,22 +116,22 @@ impl<T> AppContext<T> {
     }
 
     pub fn config(&self) -> &AppConfig {
-        &self.inner.config
+        self.inner.config()
     }
 
     #[cfg(feature = "db-sql")]
     pub fn db(&self) -> &DatabaseConnection {
-        &self.inner.db
+        self.inner.db()
     }
 
     #[cfg(feature = "sidekiq")]
     pub fn redis_enqueue(&self) -> &sidekiq::RedisPool {
-        &self.inner.redis_enqueue
+        self.inner.redis_enqueue()
     }
 
     #[cfg(feature = "sidekiq")]
     pub fn redis_fetch(&self) -> &Option<sidekiq::RedisPool> {
-        &self.inner.redis_fetch
+        self.inner.redis_fetch()
     }
 
     pub fn custom(&self) -> &T {
@@ -108,7 +139,6 @@ impl<T> AppContext<T> {
     }
 }
 
-#[derive(Debug)]
 struct AppContextInner {
     config: AppConfig,
     #[cfg(feature = "db-sql")]
@@ -122,24 +152,25 @@ struct AppContextInner {
     redis_fetch: Option<sidekiq::RedisPool>,
 }
 
-#[cfg(test)]
-mockall::mock! {
-    pub AppContext<T: 'static = ()> {
-        pub fn config(&self) -> &AppConfig;
-
-        #[cfg(feature = "db-sql")]
-        pub fn db(&self) -> &DatabaseConnection;
-
-        #[cfg(feature = "sidekiq")]
-        pub fn redis_enqueue(&self) -> &sidekiq::RedisPool;
-
-        #[cfg(feature = "sidekiq")]
-        pub fn redis_fetch(&self) -> &Option<sidekiq::RedisPool>;
-
-        pub fn with_custom<NewT: 'static>(self, custom: NewT) -> MockAppContext<NewT>;
+#[cfg_attr(test, mockall::automock)]
+#[cfg_attr(test, allow(dead_code))]
+impl AppContextInner {
+    fn config(&self) -> &AppConfig {
+        &self.config
     }
 
-    impl<T> Clone for AppContext<T> {
-        fn clone(&self) -> Self;
+    #[cfg(feature = "db-sql")]
+    fn db(&self) -> &DatabaseConnection {
+        &self.db
+    }
+
+    #[cfg(feature = "sidekiq")]
+    fn redis_enqueue(&self) -> &sidekiq::RedisPool {
+        &self.redis_enqueue
+    }
+
+    #[cfg(feature = "sidekiq")]
+    fn redis_fetch(&self) -> &Option<sidekiq::RedisPool> {
+        &self.redis_fetch
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,7 +1,6 @@
 use crate::app::App;
 #[cfg(test)]
 use crate::app::MockApp;
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::cli::roadster::{RoadsterCli, RunRoadsterCommand};
 use async_trait::async_trait;

--- a/src/cli/roadster/migrate.rs
+++ b/src/cli/roadster/migrate.rs
@@ -6,7 +6,6 @@ use serde_derive::Serialize;
 use tracing::warn;
 
 use crate::app::App;
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::cli::roadster::{RoadsterCli, RunRoadsterCommand};
 

--- a/src/cli/roadster/mod.rs
+++ b/src/cli/roadster/mod.rs
@@ -1,5 +1,4 @@
 use crate::app::App;
-#[mockall_double::double]
 use crate::app_context::AppContext;
 #[cfg(feature = "open-api")]
 use crate::cli::roadster::list_routes::ListRoutesArgs;

--- a/src/cli/roadster/print_config.rs
+++ b/src/cli/roadster/print_config.rs
@@ -5,7 +5,6 @@ use strum_macros::{EnumString, IntoStaticStr};
 use tracing::info;
 
 use crate::app::App;
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::cli::roadster::{RoadsterCli, RunRoadsterCommand};
 

--- a/src/config/app_config.rs
+++ b/src/config/app_config.rs
@@ -93,7 +93,7 @@ impl AppConfig {
     }
 
     #[cfg(test)]
-    pub(crate) fn empty(config_str: Option<&str>) -> anyhow::Result<Self> {
+    pub(crate) fn test(config_str: Option<&str>) -> anyhow::Result<Self> {
         let config = config_str.unwrap_or(
             r#"
             environment = "test"
@@ -242,6 +242,6 @@ mod tests {
     #[test]
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn empty() {
-        AppConfig::empty(None).unwrap();
+        AppConfig::test(None).unwrap();
     }
 }

--- a/src/config/service/http/initializer.rs
+++ b/src/config/service/http/initializer.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::config::app_config::CustomConfig;
 use crate::service::http::initializer::normalize_path::NormalizePathConfig;

--- a/src/config/service/http/middleware.rs
+++ b/src/config/service/http/middleware.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::config::app_config::CustomConfig;
 use crate::service::http::middleware::catch_panic::CatchPanicConfig;
@@ -171,7 +170,6 @@ impl<T: Default> MiddlewareConfig<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app_context::MockAppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
     use serde_json::Value;
@@ -190,11 +188,10 @@ mod tests {
         #[case] expected_enabled: bool,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.middleware.default_enable = default_enable;
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let common_config = CommonConfig {
             enable,

--- a/src/config/service/http/mod.rs
+++ b/src/config/service/http/mod.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::config::service::http::initializer::Initializer;
 use crate::config::service::http::middleware::Middleware;

--- a/src/config/service/mod.rs
+++ b/src/config/service/mod.rs
@@ -2,7 +2,6 @@
 pub mod http;
 pub mod worker;
 
-#[mockall_double::double]
 use crate::app_context::AppContext;
 #[cfg(feature = "http")]
 use crate::config::service::http::HttpServiceConfig;

--- a/src/controller/http/docs.rs
+++ b/src/controller/http/docs.rs
@@ -1,8 +1,4 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
-use std::ops::Deref;
-use std::sync::Arc;
-
 use crate::config::app_config::AppConfig;
 use crate::controller::http::build_path;
 use aide::axum::routing::get_with;
@@ -12,6 +8,8 @@ use aide::redoc::Redoc;
 use aide::scalar::Scalar;
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
+use std::ops::Deref;
+use std::sync::Arc;
 
 const BASE: &str = "_docs";
 const TAG: &str = "Docs";
@@ -146,8 +144,6 @@ fn api_schema_route<S>(context: &AppContext<S>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::MockApp;
-    use crate::app_context::MockAppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
 
@@ -165,7 +161,7 @@ mod tests {
         #[case] route: Option<String>,
         #[case] enabled: bool,
     ) {
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.default_routes.default_enable = default_enable;
         config.service.http.custom.default_routes.scalar.enable = enable;
         config
@@ -176,8 +172,7 @@ mod tests {
             .scalar
             .route
             .clone_from(&route);
-        let mut context = MockAppContext::<MockApp>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         assert_eq!(scalar_enabled(&context), enabled);
         assert_eq!(
@@ -198,7 +193,7 @@ mod tests {
         #[case] route: Option<String>,
         #[case] enabled: bool,
     ) {
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.default_routes.default_enable = default_enable;
         config.service.http.custom.default_routes.redoc.enable = enable;
         config
@@ -209,8 +204,7 @@ mod tests {
             .redoc
             .route
             .clone_from(&route);
-        let mut context = MockAppContext::<MockApp>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         assert_eq!(redoc_enabled(&context), enabled);
         assert_eq!(
@@ -231,7 +225,7 @@ mod tests {
         #[case] route: Option<String>,
         #[case] enabled: bool,
     ) {
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.default_routes.default_enable = default_enable;
         config.service.http.custom.default_routes.api_schema.enable = enable;
         config
@@ -242,8 +236,7 @@ mod tests {
             .api_schema
             .route
             .clone_from(&route);
-        let mut context = MockAppContext::<MockApp>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         assert_eq!(api_schema_enabled(&context), enabled);
         assert_eq!(

--- a/src/controller/http/health.rs
+++ b/src/controller/http/health.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::config::app_config::AppConfig;
 use crate::controller::http::build_path;
@@ -249,8 +248,7 @@ fn health_get_docs(op: TransformOperation) -> TransformOperation {
 
 #[cfg(test)]
 mod tests {
-    use crate::app::MockApp;
-    use crate::app_context::MockAppContext;
+    use crate::app_context::AppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
 
@@ -268,7 +266,7 @@ mod tests {
         #[case] route: Option<String>,
         #[case] enabled: bool,
     ) {
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.default_routes.default_enable = default_enable;
         config.service.http.custom.default_routes.health.enable = enable;
         config
@@ -279,8 +277,7 @@ mod tests {
             .health
             .route
             .clone_from(&route);
-        let mut context = MockAppContext::<MockApp>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         assert_eq!(super::enabled(&context), enabled);
         assert_eq!(

--- a/src/controller/http/mod.rs
+++ b/src/controller/http/mod.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 #[cfg(feature = "open-api")]
 use aide::axum::ApiRouter;

--- a/src/controller/http/ping.rs
+++ b/src/controller/http/ping.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::config::app_config::AppConfig;
 use crate::controller::http::build_path;
@@ -88,8 +87,7 @@ fn ping_get_docs(op: TransformOperation) -> TransformOperation {
 
 #[cfg(test)]
 mod tests {
-    use crate::app::MockApp;
-    use crate::app_context::MockAppContext;
+    use crate::app_context::AppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
 
@@ -107,7 +105,7 @@ mod tests {
         #[case] route: Option<String>,
         #[case] enabled: bool,
     ) {
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.default_routes.default_enable = default_enable;
         config.service.http.custom.default_routes.ping.enable = enable;
         config
@@ -118,8 +116,7 @@ mod tests {
             .ping
             .route
             .clone_from(&route);
-        let mut context = MockAppContext::<MockApp>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         assert_eq!(super::enabled(&context), enabled);
         assert_eq!(

--- a/src/middleware/http/auth/jwt/mod.rs
+++ b/src/middleware/http/auth/jwt/mod.rs
@@ -3,7 +3,6 @@ pub mod ietf;
 #[cfg(feature = "jwt-openid")]
 pub mod openid;
 
-#[mockall_double::double]
 use crate::app_context::AppContext;
 #[cfg(feature = "jwt-ietf")]
 use crate::middleware::http::auth::jwt::ietf::Claims;

--- a/src/service/http/builder.rs
+++ b/src/service/http/builder.rs
@@ -1,5 +1,4 @@
 use crate::app::App;
-#[mockall_double::double]
 use crate::app_context::AppContext;
 #[cfg(feature = "open-api")]
 use crate::controller::http::default_api_routes;
@@ -213,7 +212,7 @@ impl<A: App> AppServiceBuilder<A, HttpService> for HttpServiceBuilder<A> {
 mod tests {
     use super::*;
     use crate::app::MockApp;
-    use crate::app_context::MockAppContext;
+    use crate::app_context::AppContext;
     use crate::service::http::initializer::MockInitializer;
     use crate::service::http::middleware::MockMiddleware;
 
@@ -221,10 +220,7 @@ mod tests {
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn middleware() {
         // Arrange
-        let mut context = MockAppContext::<()>::default();
-        context
-            .expect_clone()
-            .returning(MockAppContext::<()>::default);
+        let context = AppContext::<()>::test(None, None).unwrap();
         let builder = HttpServiceBuilder::<MockApp>::empty(&context);
 
         let mut middleware = MockMiddleware::default();
@@ -243,10 +239,7 @@ mod tests {
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn middleware_not_enabled() {
         // Arrange
-        let mut context = MockAppContext::<()>::default();
-        context
-            .expect_clone()
-            .returning(MockAppContext::<()>::default);
+        let context = AppContext::<()>::test(None, None).unwrap();
         let builder = HttpServiceBuilder::<MockApp>::empty(&context);
 
         let mut middleware = MockMiddleware::default();
@@ -264,10 +257,7 @@ mod tests {
     #[should_panic]
     fn middleware_already_registered() {
         // Arrange
-        let mut context = MockAppContext::<()>::default();
-        context
-            .expect_clone()
-            .returning(MockAppContext::<()>::default);
+        let context = AppContext::<()>::test(None, None).unwrap();
         let builder = HttpServiceBuilder::<MockApp>::empty(&context);
 
         let mut middleware = MockMiddleware::default();
@@ -285,10 +275,7 @@ mod tests {
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn initializer() {
         // Arrange
-        let mut context = MockAppContext::<()>::default();
-        context
-            .expect_clone()
-            .returning(MockAppContext::<()>::default);
+        let context = AppContext::<()>::test(None, None).unwrap();
         let builder = HttpServiceBuilder::<MockApp>::empty(&context);
 
         let mut initializer = MockInitializer::default();
@@ -307,10 +294,7 @@ mod tests {
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn initializer_not_enabled() {
         // Arrange
-        let mut context = MockAppContext::<()>::default();
-        context
-            .expect_clone()
-            .returning(MockAppContext::<()>::default);
+        let context = AppContext::<()>::test(None, None).unwrap();
         let builder = HttpServiceBuilder::<MockApp>::empty(&context);
 
         let mut initializer = MockInitializer::default();
@@ -328,10 +312,7 @@ mod tests {
     #[should_panic]
     fn initializer_already_registered() {
         // Arrange
-        let mut context = MockAppContext::<()>::default();
-        context
-            .expect_clone()
-            .returning(MockAppContext::<()>::default);
+        let context = AppContext::<()>::test(None, None).unwrap();
         let builder = HttpServiceBuilder::<MockApp>::empty(&context);
 
         let mut initializer = MockInitializer::default();

--- a/src/service/http/initializer/default.rs
+++ b/src/service/http/initializer/default.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::initializer::normalize_path::NormalizePathInitializer;
 use crate::service::http::initializer::Initializer;
@@ -17,7 +16,7 @@ pub fn default_initializers<S: Send + Sync + 'static>(
 
 #[cfg(test)]
 mod tests {
-    use crate::app_context::MockAppContext;
+    use crate::app_context::AppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
 
@@ -27,11 +26,10 @@ mod tests {
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn default_initializers(#[case] default_enable: bool, #[case] expected_size: usize) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.initializer.default_enable = default_enable;
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         // Act
         let middleware = super::default_initializers(&context);

--- a/src/service/http/initializer/mod.rs
+++ b/src/service/http/initializer/mod.rs
@@ -1,7 +1,6 @@
 pub mod default;
 pub mod normalize_path;
 
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use axum::Router;
 

--- a/src/service/http/initializer/normalize_path.rs
+++ b/src/service/http/initializer/normalize_path.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::initializer::Initializer;
 use axum::Router;

--- a/src/service/http/middleware/catch_panic.rs
+++ b/src/service/http/middleware/catch_panic.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::Middleware;
 use axum::Router;
@@ -49,7 +48,6 @@ impl<S: Send + Sync + 'static> Middleware<S> for CatchPanicMiddleware {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app_context::MockAppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
 
@@ -63,7 +61,7 @@ mod tests {
         #[case] expected_enabled: bool,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.middleware.default_enable = default_enable;
         config
             .service
@@ -74,8 +72,7 @@ mod tests {
             .common
             .enable = enable;
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = CatchPanicMiddleware;
 
@@ -89,7 +86,7 @@ mod tests {
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn priority(#[case] override_priority: Option<i32>, #[case] expected_priority: i32) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         if let Some(priority) = override_priority {
             config
                 .service
@@ -101,8 +98,7 @@ mod tests {
                 .priority = priority;
         }
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = CatchPanicMiddleware;
 

--- a/src/service/http/middleware/compression.rs
+++ b/src/service/http/middleware/compression.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::Middleware;
 use axum::Router;
@@ -92,7 +91,7 @@ impl<S: Send + Sync + 'static> Middleware<S> for RequestDecompressionMiddleware 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app_context::MockAppContext;
+    use crate::app_context::AppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
 
@@ -106,7 +105,7 @@ mod tests {
         #[case] expected_enabled: bool,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.middleware.default_enable = default_enable;
         config
             .service
@@ -117,8 +116,7 @@ mod tests {
             .common
             .enable = enable;
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = ResponseCompressionMiddleware;
 
@@ -135,7 +133,7 @@ mod tests {
         #[case] expected_priority: i32,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         if let Some(priority) = override_priority {
             config
                 .service
@@ -147,8 +145,7 @@ mod tests {
                 .priority = priority;
         }
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = ResponseCompressionMiddleware;
 
@@ -166,7 +163,7 @@ mod tests {
         #[case] expected_enabled: bool,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.middleware.default_enable = default_enable;
         config
             .service
@@ -177,8 +174,7 @@ mod tests {
             .common
             .enable = enable;
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = RequestDecompressionMiddleware;
 
@@ -195,7 +191,7 @@ mod tests {
         #[case] expected_priority: i32,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         if let Some(priority) = override_priority {
             config
                 .service
@@ -207,8 +203,7 @@ mod tests {
                 .priority = priority;
         }
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = RequestDecompressionMiddleware;
 

--- a/src/service/http/middleware/default.rs
+++ b/src/service/http/middleware/default.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::catch_panic::CatchPanicMiddleware;
 use crate::service::http::middleware::compression::RequestDecompressionMiddleware;
@@ -37,7 +36,7 @@ pub fn default_middleware<S: Send + Sync + 'static>(
 
 #[cfg(test)]
 mod tests {
-    use crate::app_context::MockAppContext;
+    use crate::app_context::AppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
 
@@ -47,11 +46,10 @@ mod tests {
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn default_middleware(#[case] default_enable: bool, #[case] expected_size: usize) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.middleware.default_enable = default_enable;
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         // Act
         let middleware = super::default_middleware(&context);

--- a/src/service/http/middleware/mod.rs
+++ b/src/service/http/middleware/mod.rs
@@ -7,7 +7,6 @@ pub mod size_limit;
 pub mod timeout;
 pub mod tracing;
 
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use axum::Router;
 

--- a/src/service/http/middleware/request_id.rs
+++ b/src/service/http/middleware/request_id.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::Middleware;
 use axum::http::HeaderName;
@@ -141,7 +140,6 @@ impl<S: Send + Sync + 'static> Middleware<S> for PropagateRequestIdMiddleware {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app_context::MockAppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
 
@@ -155,7 +153,7 @@ mod tests {
         #[case] expected_enabled: bool,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.middleware.default_enable = default_enable;
         config
             .service
@@ -166,8 +164,7 @@ mod tests {
             .common
             .enable = enable;
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = SetRequestIdMiddleware;
 
@@ -184,7 +181,7 @@ mod tests {
         #[case] expected_priority: i32,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         if let Some(priority) = override_priority {
             config
                 .service
@@ -196,8 +193,7 @@ mod tests {
                 .priority = priority;
         }
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = SetRequestIdMiddleware;
 
@@ -215,7 +211,7 @@ mod tests {
         #[case] expected_enabled: bool,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.middleware.default_enable = default_enable;
         config
             .service
@@ -226,8 +222,7 @@ mod tests {
             .common
             .enable = enable;
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = PropagateRequestIdMiddleware;
 
@@ -244,7 +239,7 @@ mod tests {
         #[case] expected_priority: i32,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         if let Some(priority) = override_priority {
             config
                 .service
@@ -256,8 +251,7 @@ mod tests {
                 .priority = priority;
         }
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = PropagateRequestIdMiddleware;
 

--- a/src/service/http/middleware/sensitive_headers.rs
+++ b/src/service/http/middleware/sensitive_headers.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::Middleware;
 use axum::http::{header, HeaderName};
@@ -152,7 +151,7 @@ impl<S: Send + Sync + 'static> Middleware<S> for SensitiveResponseHeadersMiddlew
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app_context::MockAppContext;
+    use crate::app_context::AppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
 
@@ -166,7 +165,7 @@ mod tests {
         #[case] expected_enabled: bool,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.middleware.default_enable = default_enable;
         config
             .service
@@ -177,8 +176,7 @@ mod tests {
             .common
             .enable = enable;
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = SensitiveRequestHeadersMiddleware;
 
@@ -195,7 +193,7 @@ mod tests {
         #[case] expected_priority: i32,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         if let Some(priority) = override_priority {
             config
                 .service
@@ -207,8 +205,7 @@ mod tests {
                 .priority = priority;
         }
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = SensitiveRequestHeadersMiddleware;
 
@@ -226,7 +223,7 @@ mod tests {
         #[case] expected_enabled: bool,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.middleware.default_enable = default_enable;
         config
             .service
@@ -237,8 +234,7 @@ mod tests {
             .common
             .enable = enable;
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = SensitiveResponseHeadersMiddleware;
 
@@ -255,7 +251,7 @@ mod tests {
         #[case] expected_priority: i32,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         if let Some(priority) = override_priority {
             config
                 .service
@@ -267,8 +263,7 @@ mod tests {
                 .priority = priority;
         }
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = SensitiveResponseHeadersMiddleware;
 

--- a/src/service/http/middleware/size_limit.rs
+++ b/src/service/http/middleware/size_limit.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::Middleware;
 use anyhow::bail;
@@ -81,7 +80,6 @@ impl<S: Send + Sync + 'static> Middleware<S> for RequestBodyLimitMiddleware {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app_context::MockAppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
 
@@ -95,7 +93,7 @@ mod tests {
         #[case] expected_enabled: bool,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.middleware.default_enable = default_enable;
         config
             .service
@@ -106,8 +104,7 @@ mod tests {
             .common
             .enable = enable;
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = RequestBodyLimitMiddleware;
 
@@ -121,7 +118,7 @@ mod tests {
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn size_limit_priority(#[case] override_priority: Option<i32>, #[case] expected_priority: i32) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         if let Some(priority) = override_priority {
             config
                 .service
@@ -133,8 +130,7 @@ mod tests {
                 .priority = priority;
         }
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = RequestBodyLimitMiddleware;
 

--- a/src/service/http/middleware/timeout.rs
+++ b/src/service/http/middleware/timeout.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::Middleware;
 use axum::Router;
@@ -73,7 +72,6 @@ impl<S: Send + Sync + 'static> Middleware<S> for TimeoutMiddleware {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app_context::MockAppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
 
@@ -87,12 +85,11 @@ mod tests {
         #[case] expected_enabled: bool,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.middleware.default_enable = default_enable;
         config.service.http.custom.middleware.timeout.common.enable = enable;
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = TimeoutMiddleware;
 
@@ -106,7 +103,7 @@ mod tests {
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn timeout_priority(#[case] override_priority: Option<i32>, #[case] expected_priority: i32) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         if let Some(priority) = override_priority {
             config
                 .service
@@ -118,8 +115,7 @@ mod tests {
                 .priority = priority;
         }
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = TimeoutMiddleware;
 

--- a/src/service/http/middleware/tracing.rs
+++ b/src/service/http/middleware/tracing.rs
@@ -1,4 +1,3 @@
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::http::middleware::Middleware;
 use axum::extract::MatchedPath;
@@ -170,7 +169,6 @@ impl<B> OnResponse<B> for CustomOnResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app_context::MockAppContext;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
 
@@ -184,12 +182,11 @@ mod tests {
         #[case] expected_enabled: bool,
     ) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.middleware.default_enable = default_enable;
         config.service.http.custom.middleware.tracing.common.enable = enable;
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = TracingMiddleware;
 
@@ -203,7 +200,7 @@ mod tests {
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn tracing_priority(#[case] override_priority: Option<i32>, #[case] expected_priority: i32) {
         // Arrange
-        let mut config = AppConfig::empty(None).unwrap();
+        let mut config = AppConfig::test(None).unwrap();
         if let Some(priority) = override_priority {
             config
                 .service
@@ -215,8 +212,7 @@ mod tests {
                 .priority = priority;
         }
 
-        let mut context = MockAppContext::<()>::default();
-        context.expect_config().return_const(config);
+        let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         let middleware = TracingMiddleware;
 

--- a/src/service/http/service.rs
+++ b/src/service/http/service.rs
@@ -1,5 +1,4 @@
 use crate::app::App;
-#[mockall_double::double]
 use crate::app_context::AppContext;
 #[cfg(feature = "cli")]
 use crate::cli::roadster::RoadsterCli;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,5 +1,4 @@
 use crate::app::App;
-#[mockall_double::double]
 use crate::app_context::AppContext;
 #[cfg(feature = "cli")]
 use crate::cli::roadster::RoadsterCli;
@@ -80,7 +79,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::app::MockApp;
-    use crate::app_context::MockAppContext;
+    use crate::app_context::AppContext;
     use crate::service::{AppServiceBuilder, MockAppService};
     use async_trait::async_trait;
     use rstest::rstest;
@@ -89,10 +88,7 @@ mod tests {
     #[async_trait]
     impl AppServiceBuilder<MockApp, MockAppService<MockApp>> for TestAppServiceBuilder {
         #[cfg_attr(coverage_nightly, coverage(off))]
-        async fn build(
-            self,
-            _context: &MockAppContext<()>,
-        ) -> anyhow::Result<MockAppService<MockApp>> {
+        async fn build(self, _context: &AppContext<()>) -> anyhow::Result<MockAppService<MockApp>> {
             Ok(MockAppService::default())
         }
     }
@@ -103,8 +99,7 @@ mod tests {
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn builder_enabled(#[case] service_enabled: bool) {
         // Arrange
-        let mut context = MockAppContext::default();
-        context.expect_clone().returning(MockAppContext::default);
+        let context = AppContext::<()>::test(None, None).unwrap();
 
         let enabled_ctx = MockAppService::<MockApp>::enabled_context();
         enabled_ctx.expect().returning(move |_| service_enabled);

--- a/src/service/registry.rs
+++ b/src/service/registry.rs
@@ -1,5 +1,4 @@
 use crate::app::App;
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::{AppService, AppServiceBuilder};
 use anyhow::bail;
@@ -71,7 +70,6 @@ impl<A: App> ServiceRegistry<A> {
 mod tests {
     use super::*;
     use crate::app::MockApp;
-    use crate::app_context::MockAppContext;
     use crate::service::{MockAppService, MockAppServiceBuilder};
     use rstest::rstest;
 
@@ -81,8 +79,7 @@ mod tests {
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn register_service(#[case] service_enabled: bool, #[case] expected_count: usize) {
         // Arrange
-        let mut context = MockAppContext::default();
-        context.expect_clone().returning(MockAppContext::default);
+        let context = AppContext::<()>::test(None, None).unwrap();
 
         let service: MockAppService<MockApp> = MockAppService::default();
         let enabled_ctx = MockAppService::<MockApp>::enabled_context();
@@ -112,8 +109,7 @@ mod tests {
         #[case] expected_count: usize,
     ) {
         // Arrange
-        let mut context = MockAppContext::default();
-        context.expect_clone().returning(MockAppContext::default);
+        let context = AppContext::<()>::test(None, None).unwrap();
 
         let enabled_ctx = MockAppService::<MockApp>::enabled_context();
         enabled_ctx.expect().returning(move |_| service_enabled);

--- a/src/service/runner.rs
+++ b/src/service/runner.rs
@@ -1,5 +1,4 @@
 use crate::app::App;
-#[mockall_double::double]
 use crate::app_context::AppContext;
 #[cfg(feature = "cli")]
 use crate::cli::roadster::RoadsterCli;

--- a/src/service/worker/sidekiq/app_worker.rs
+++ b/src/service/worker/sidekiq/app_worker.rs
@@ -1,5 +1,4 @@
 use crate::app::App;
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use async_trait::async_trait;
 use serde_derive::{Deserialize, Serialize};

--- a/src/service/worker/sidekiq/roadster_worker.rs
+++ b/src/service/worker/sidekiq/roadster_worker.rs
@@ -1,5 +1,4 @@
 use crate::app::App;
-#[mockall_double::double]
 use crate::app_context::AppContext;
 use crate::service::worker::sidekiq::app_worker::AppWorker;
 use crate::service::worker::sidekiq::app_worker::AppWorkerConfig;


### PR DESCRIPTION
There are some inconveniences of using a mock `AppContext`:

1. Need to use `mockall_double` when importing `AppContext` whenever it's needed for tests. This isn't a huge deal but is a little annoying.
2. Need to update the `mock!` any time definitions in the `AppContext` impl change
3. Code completion doesn't seem to be working -- `context.config()` doesn't show up, nor do the fields on the config.

However there is at least one benefit:
1. In order to create a concrete redis pool, the creation code needs to run in an async context. This means that any test that needs the `AppContext` needs to run with `#[tokio::test]`. This isn't a huge deal, but is slightly inconvenient. However, using a mock `AppContext` removes this requirement (aside from the few tests that still need a concrete redis pool).

To get the above benefit of a mock `AppContext` without the listed cons, we can mock just the `AppContextInner` that we already created for the `AppContext`. Then, we can still create the `AppContext` in tests without needing to create a concrete redis pool, code completiong works, and we don't need to sprinkle `mockall_double` everywhere (for the `AppContext` at least).

Also, make `mockall_double` a dev dependency

Closes https://github.com/roadster-rs/roadster/issues/154