### PR TITLE
Allow partial overrides of all configs

### DIFF
--- a/examples/minimal/config/default.toml
+++ b/examples/minimal/config/default.toml
@@ -1,5 +1,6 @@
 [app]
 name = "Minimal Example"
+
 [tracing]
 level = "debug"
 

--- a/src/config/auth/mod.rs
+++ b/src/config/auth/mod.rs
@@ -1,0 +1,83 @@
+use crate::util::serde_util::UriOrString;
+use serde_derive::{Deserialize, Serialize};
+use validator::Validate;
+
+#[derive(Debug, Clone, Validate, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Auth {
+    #[validate(nested)]
+    pub jwt: Jwt,
+}
+
+#[derive(Debug, Clone, Validate, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Jwt {
+    pub secret: String,
+    #[serde(default)]
+    #[validate(nested)]
+    pub claims: JwtClaims,
+}
+
+#[derive(Debug, Clone, Default, Validate, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct JwtClaims {
+    // Todo: Default to the server URL?
+    #[serde(default)]
+    pub audience: Vec<UriOrString>,
+    /// Claim names to require, in addition to the default-required `exp` claim.
+    #[serde(default)]
+    pub required_claims: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::test_util::TestCase;
+    use insta::assert_toml_snapshot;
+    use rstest::{fixture, rstest};
+
+    #[fixture]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn case() -> TestCase {
+        Default::default()
+    }
+
+    #[rstest]
+    #[case(
+        r#"
+        [jwt]
+        secret = "foo"
+        "#
+    )]
+    #[case(
+        r#"
+        [jwt]
+        secret = "foo"
+        [jwt.claims]
+        audience = ["bar"]
+        "#
+    )]
+    #[case(
+        r#"
+        [jwt]
+        secret = "foo"
+        [jwt.claims]
+        required-claims = ["baz"]
+        "#
+    )]
+    #[case(
+        r#"
+        [jwt]
+        secret = "foo"
+        [jwt.claims]
+        audience = ["bar"]
+        required-claims = ["baz"]
+        "#
+    )]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn auth(_case: TestCase, #[case] config: &str) {
+        let auth: Auth = toml::from_str(config).unwrap();
+
+        assert_toml_snapshot!(auth);
+    }
+}

--- a/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_1.snap
+++ b/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_1.snap
@@ -1,0 +1,10 @@
+---
+source: src/config/auth/mod.rs
+expression: auth
+---
+[jwt]
+secret = 'foo'
+
+[jwt.claims]
+audience = []
+required-claims = []

--- a/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_2.snap
+++ b/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_2.snap
@@ -1,0 +1,10 @@
+---
+source: src/config/auth/mod.rs
+expression: auth
+---
+[jwt]
+secret = 'foo'
+
+[jwt.claims]
+audience = ['bar']
+required-claims = []

--- a/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_3.snap
+++ b/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_3.snap
@@ -1,0 +1,10 @@
+---
+source: src/config/auth/mod.rs
+expression: auth
+---
+[jwt]
+secret = 'foo'
+
+[jwt.claims]
+audience = []
+required-claims = ['baz']

--- a/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_4.snap
+++ b/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_4.snap
@@ -1,0 +1,10 @@
+---
+source: src/config/auth/mod.rs
+expression: auth
+---
+[jwt]
+secret = 'foo'
+
+[jwt.claims]
+audience = ['bar']
+required-claims = ['baz']

--- a/src/config/database.rs
+++ b/src/config/database.rs
@@ -1,0 +1,79 @@
+use serde_derive::{Deserialize, Serialize};
+use serde_with::serde_as;
+use std::time::Duration;
+use url::Url;
+use validator::Validate;
+
+#[serde_as]
+#[derive(Debug, Clone, Validate, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Database {
+    /// This can be overridden with an environment variable, e.g. `ROADSTER.DATABASE.URI=postgres://example:example@example:1234/example_app`
+    pub uri: Url,
+    /// Whether to automatically apply migrations during the app's start up. Migrations can also
+    /// be manually performed via the `roadster migration [COMMAND]` CLI command.
+    pub auto_migrate: bool,
+    #[serde(default = "Database::default_connect_timeout")]
+    #[serde_as(as = "serde_with::DurationMilliSeconds")]
+    pub connect_timeout: Duration,
+    #[serde(default = "Database::default_acquire_timeout")]
+    #[serde_as(as = "serde_with::DurationMilliSeconds")]
+    pub acquire_timeout: Duration,
+    #[serde_as(as = "Option<serde_with::DurationSeconds>")]
+    pub idle_timeout: Option<Duration>,
+    #[serde_as(as = "Option<serde_with::DurationSeconds>")]
+    pub max_lifetime: Option<Duration>,
+    #[serde(default)]
+    pub min_connections: u32,
+    pub max_connections: u32,
+}
+
+impl Database {
+    fn default_connect_timeout() -> Duration {
+        Duration::from_millis(1000)
+    }
+
+    fn default_acquire_timeout() -> Duration {
+        Duration::from_millis(1000)
+    }
+}
+
+#[cfg(test)]
+mod deserialize_tests {
+    use super::*;
+    use crate::util::test_util::TestCase;
+    use insta::assert_toml_snapshot;
+    use rstest::{fixture, rstest};
+
+    #[fixture]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn case() -> TestCase {
+        Default::default()
+    }
+
+    #[rstest]
+    #[case(
+        r#"
+        uri = "https://example.com:1234"
+        auto-migrate = true
+        max-connections = 1
+        "#
+    )]
+    #[case(
+        r#"
+        uri = "https://example.com:1234"
+        auto-migrate = true
+        max-connections = 1
+        connect-timeout = 1000
+        acquire-timeout = 2000
+        idle-timeout = 3000
+        max-lifetime = 4000
+        "#
+    )]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn sidekiq(_case: TestCase, #[case] config: &str) {
+        let database: Database = toml::from_str(config).unwrap();
+
+        assert_toml_snapshot!(database);
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,7 @@
 pub mod app_config;
+pub mod auth;
+#[cfg(feature = "db-sql")]
+pub mod database;
 pub mod environment;
 pub mod service;
+pub mod tracing;

--- a/src/config/service/http/default_routes.rs
+++ b/src/config/service/http/default_routes.rs
@@ -1,0 +1,339 @@
+use crate::app_context::AppContext;
+use crate::util::serde_util;
+use crate::util::serde_util::default_true;
+use serde_derive::{Deserialize, Serialize};
+use validator::Validate;
+use validator::ValidationError;
+
+#[derive(Debug, Clone, Validate, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[validate(schema(function = "validate_default_routes"))]
+pub struct DefaultRoutes {
+    #[serde(default = "default_true")]
+    pub default_enable: bool,
+
+    #[serde(deserialize_with = "deserialize_ping", default = "default_ping")]
+    pub ping: DefaultRouteConfig,
+
+    #[serde(deserialize_with = "deserialize_health", default = "default_health")]
+    pub health: DefaultRouteConfig,
+
+    #[cfg(feature = "open-api")]
+    #[serde(
+        deserialize_with = "deserialize_api_schema",
+        default = "default_api_schema"
+    )]
+    pub api_schema: DefaultRouteConfig,
+
+    #[cfg(feature = "open-api")]
+    #[serde(deserialize_with = "deserialize_scalar", default = "default_scalar")]
+    pub scalar: DefaultRouteConfig,
+
+    #[cfg(feature = "open-api")]
+    #[serde(deserialize_with = "deserialize_redoc", default = "default_redoc")]
+    pub redoc: DefaultRouteConfig,
+}
+
+impl Default for DefaultRoutes {
+    fn default() -> Self {
+        Self {
+            default_enable: default_true(),
+            ping: default_ping(),
+            health: default_health(),
+            #[cfg(feature = "open-api")]
+            api_schema: default_api_schema(),
+            #[cfg(feature = "open-api")]
+            scalar: default_scalar(),
+            #[cfg(feature = "open-api")]
+            redoc: default_redoc(),
+        }
+    }
+}
+
+fn validate_default_routes(
+    // This parameter isn't used for some feature flag combinations
+    #[allow(unused)] default_routes: &DefaultRoutes,
+) -> Result<(), ValidationError> {
+    #[cfg(feature = "open-api")]
+    {
+        let default_enable = default_routes.default_enable;
+        let api_schema_enabled = default_routes.api_schema.enable.unwrap_or(default_enable);
+        let scalar_enabled = default_routes.scalar.enable.unwrap_or(default_enable);
+        let redoc_enabled = default_routes.redoc.enable.unwrap_or(default_enable);
+
+        if scalar_enabled && !api_schema_enabled {
+            return Err(ValidationError::new(
+                "The Open API schema route must be enabled in order to use the Scalar docs route.",
+            ));
+        }
+        if redoc_enabled && !api_schema_enabled {
+            return Err(ValidationError::new(
+                "The Open API schema route must be enabled in order to use the Redoc docs route.",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DefaultRouteConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enable: Option<bool>,
+    pub route: String,
+}
+
+impl DefaultRouteConfig {
+    pub fn enabled<S>(&self, context: &AppContext<S>) -> bool {
+        self.enable.unwrap_or(
+            context
+                .config()
+                .service
+                .http
+                .custom
+                .default_routes
+                .default_enable,
+        )
+    }
+}
+
+// This fun boilerplate allows the user to
+// 1. Partially override a config without needing to provide all of the required values for the config
+// 2. Prevent a type's `Default` implementation from being used and overriding the default we
+//    actually want. For example, we provide a default for the `route` fields, and we want that
+//    value to be used if the user doesn't provide one, not the type's default (`""` in this case).
+//
+// See: https://users.rust-lang.org/t/serde-default-value-for-struct-field-depending-on-parent/73452/2
+//
+// This is mainly needed because all of the default routes share a struct for their common configs,
+// so we can't simply set a default on the field directly with a serde annotation.
+// An alternative implementation could be to have different structs for each default route's common
+// config instead of sharing a struct type. However, that would still require a lot of boilerplate.
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+struct PartialDefaultRouteConfig {
+    pub enable: Option<bool>,
+    pub route: Option<String>,
+}
+
+fn deserialize_ping<'de, D>(deserializer: D) -> Result<DefaultRouteConfig, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    serde::Deserialize::deserialize(deserializer).map(map_empty_config("_ping".to_string()))
+}
+
+fn default_ping() -> DefaultRouteConfig {
+    deserialize_ping(serde_util::empty_json_object()).unwrap()
+}
+
+fn deserialize_health<'de, D>(deserializer: D) -> Result<DefaultRouteConfig, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    serde::Deserialize::deserialize(deserializer).map(map_empty_config("_health".to_string()))
+}
+
+fn default_health() -> DefaultRouteConfig {
+    deserialize_health(serde_util::empty_json_object()).unwrap()
+}
+
+#[cfg(feature = "open-api")]
+fn deserialize_api_schema<'de, D>(deserializer: D) -> Result<DefaultRouteConfig, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    serde::Deserialize::deserialize(deserializer)
+        .map(map_empty_config("_docs/api.json".to_string()))
+}
+
+#[cfg(feature = "open-api")]
+fn default_api_schema() -> DefaultRouteConfig {
+    deserialize_api_schema(serde_util::empty_json_object()).unwrap()
+}
+
+#[cfg(feature = "open-api")]
+fn deserialize_scalar<'de, D>(deserializer: D) -> Result<DefaultRouteConfig, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    serde::Deserialize::deserialize(deserializer).map(map_empty_config("_docs".to_string()))
+}
+
+#[cfg(feature = "open-api")]
+fn default_scalar() -> DefaultRouteConfig {
+    deserialize_scalar(serde_util::empty_json_object()).unwrap()
+}
+
+#[cfg(feature = "open-api")]
+fn deserialize_redoc<'de, D>(deserializer: D) -> Result<DefaultRouteConfig, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    serde::Deserialize::deserialize(deserializer).map(map_empty_config("_docs/redoc".to_string()))
+}
+
+#[cfg(feature = "open-api")]
+fn default_redoc() -> DefaultRouteConfig {
+    deserialize_redoc(serde_util::empty_json_object()).unwrap()
+}
+
+fn map_empty_config(
+    default_route: String,
+) -> impl FnOnce(PartialDefaultRouteConfig) -> DefaultRouteConfig {
+    move |PartialDefaultRouteConfig { enable, route }| DefaultRouteConfig {
+        enable,
+        route: route.unwrap_or(default_route),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::service::http::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(false, false)]
+    #[case(true, false)]
+    #[cfg(not(feature = "open-api"))]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn validate_default_routes(#[case] default_enable: bool, #[case] validation_error: bool) {
+        // Arrange
+        #[allow(clippy::field_reassign_with_default)]
+        let config = {
+            let mut config = DefaultRoutes::default();
+            config.default_enable = default_enable;
+            config
+        };
+
+        // Act
+        let result = config.validate();
+
+        // Assert
+        assert_eq!(result.is_err(), validation_error);
+    }
+
+    #[rstest]
+    #[case(false, None, None, None, false)]
+    #[case(true, None, None, None, false)]
+    #[case(false, None, Some(true), None, true)]
+    #[case(false, None, None, Some(true), true)]
+    #[case(false, Some(true), Some(true), None, false)]
+    #[case(false, Some(true), None, Some(true), false)]
+    #[cfg(feature = "open-api")]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn validate_default_routes(
+        #[case] default_enable: bool,
+        #[case] api_schema_enabled: Option<bool>,
+        #[case] scalar_enabled: Option<bool>,
+        #[case] redoc_enabled: Option<bool>,
+        #[case] validation_error: bool,
+    ) {
+        // Arrange
+        #[allow(clippy::field_reassign_with_default)]
+        let config = {
+            let mut config = DefaultRoutes::default();
+            config.default_enable = default_enable;
+            config.api_schema.enable = api_schema_enabled;
+            config.scalar.enable = scalar_enabled;
+            config.redoc.enable = redoc_enabled;
+            config
+        };
+
+        // Act
+        let result = config.validate();
+
+        // Assert
+        assert_eq!(result.is_err(), validation_error);
+    }
+}
+
+// To simplify testing, these are only run when all of the config fields are available
+#[cfg(all(test, feature = "open-api"))]
+mod deserialize_tests {
+    use super::*;
+    use crate::util::test_util::TestCase;
+    use insta::assert_toml_snapshot;
+    use rstest::{fixture, rstest};
+
+    #[fixture]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn case() -> TestCase {
+        Default::default()
+    }
+
+    #[rstest]
+    #[case("")]
+    #[case(
+        r#"
+        default-enable = false
+        [ping]
+        enable = true
+        [health]
+        enable = true
+        [api-schema]
+        enable = true
+        [scalar]
+        enable = true
+        [redoc]
+        enable = true
+        "#
+    )]
+    #[case(
+        r#"
+        default-enable = false
+        [ping]
+        enable = false
+        [health]
+        enable = false
+        [api-schema]
+        enable = false
+        [scalar]
+        enable = false
+        [redoc]
+        enable = false
+        "#
+    )]
+    #[case(
+        r#"
+        default-enable = false
+        [ping]
+        route = "a"
+        [health]
+        route = "b"
+        [api-schema]
+        route = "c"
+        [scalar]
+        route = "d"
+        [redoc]
+        route = "e"
+        "#
+    )]
+    #[case(
+        r#"
+        [ping]
+        enable = true
+        route = "a"
+        [health]
+        enable = true
+        route = "b"
+        [api-schema]
+        enable = true
+        route = "c"
+        [scalar]
+        enable = true
+        route = "d"
+        [redoc]
+        enable = true
+        route = "e"
+        "#
+    )]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn auth(_case: TestCase, #[case] config: &str) {
+        let default_routes: DefaultRoutes = toml::from_str(config).unwrap();
+
+        assert_toml_snapshot!(default_routes);
+    }
+}

--- a/src/config/service/http/initializer.rs
+++ b/src/config/service/http/initializer.rs
@@ -1,6 +1,8 @@
 use crate::app_context::AppContext;
 use crate::config::app_config::CustomConfig;
 use crate::service::http::initializer::normalize_path::NormalizePathConfig;
+use crate::util::serde_util;
+use crate::util::serde_util::default_true;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use validator::Validate;
@@ -11,7 +13,13 @@ pub const PRIORITY_LAST: i32 = 10_000;
 #[derive(Debug, Clone, Validate, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default)]
 pub struct Initializer {
+    #[serde(default = "default_true")]
     pub default_enable: bool,
+
+    #[serde(
+        deserialize_with = "deserialize_normalize_path",
+        default = "default_normalize_path"
+    )]
     pub normalize_path: InitializerConfig<NormalizePathConfig>,
     /// Allows providing configs for custom initializers. Any configs that aren't pre-defined above
     /// will be collected here.
@@ -47,34 +55,27 @@ pub struct Initializer {
 
 impl Default for Initializer {
     fn default() -> Self {
-        let normalize_path: InitializerConfig<NormalizePathConfig> = Default::default();
-        let normalize_path = normalize_path.set_priority(PRIORITY_LAST);
-
         Self {
-            default_enable: true,
-            normalize_path,
+            default_enable: default_true(),
+            normalize_path: default_normalize_path(),
             custom: Default::default(),
         }
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case", default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct CommonConfig {
     // Optional so we can tell the difference between a consumer explicitly enabling/disabling
     // the initializer, vs the initializer being enabled/disabled by default.
     // If this is `None`, the value will match the value of `Initializer#default_enable`.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub enable: Option<bool>,
     pub priority: i32,
 }
 
 impl CommonConfig {
-    pub fn set_priority(mut self, priority: i32) -> Self {
-        self.priority = priority;
-        self
-    }
-
     pub fn enabled<S>(&self, context: &AppContext<S>) -> bool {
         self.enable.unwrap_or(
             context
@@ -88,49 +89,133 @@ impl CommonConfig {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case", default)]
-pub struct InitializerConfig<T: Default> {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct InitializerConfig<T> {
     #[serde(flatten)]
     pub common: CommonConfig,
     #[serde(flatten)]
     pub custom: T,
 }
 
-impl<T: Default> InitializerConfig<T> {
-    pub fn set_priority(mut self, priority: i32) -> Self {
-        self.common = self.common.set_priority(priority);
-        self
+// This fun boilerplate allows the user to
+// 1. Partially override a config without needing to provide all of the required values for the config
+// 2. Prevent a type's `Default` implementation from being used and overriding the default we
+//    actually want. For example, we provide a default for the `priority` fields, and we want that
+//    value to be used if the user doesn't provide one, not the type's default (`0` in this case).
+//
+// See: https://users.rust-lang.org/t/serde-default-value-for-struct-field-depending-on-parent/73452/2
+//
+// This is mainly needed because all of the initializers share a struct for their common configs,
+// so we can't simply set a default on the field directly with a serde annotation.
+// An alternative implementation could be to have different structs for each initializer's common
+// config instead of sharing a struct type. However, that would still require a lot of boilerplate.
+
+struct Priorities {
+    normalize_path: i32,
+}
+
+impl Default for Priorities {
+    fn default() -> Self {
+        let normalize_path = PRIORITY_LAST;
+
+        Self { normalize_path }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct PartialCommonConfig {
+    pub enable: Option<bool>,
+    pub priority: Option<i32>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct IncompleteInitializerConfig<T> {
+    #[serde(flatten)]
+    pub common: PartialCommonConfig,
+    #[serde(flatten)]
+    pub custom: T,
+}
+
+fn deserialize_normalize_path<'de, D, T>(deserializer: D) -> Result<InitializerConfig<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(deserializer)
+        .map(map_empty_config(Priorities::default().normalize_path))
+}
+
+fn default_normalize_path() -> InitializerConfig<NormalizePathConfig> {
+    deserialize_normalize_path(serde_util::empty_json_object()).unwrap()
+}
+
+fn map_empty_config<T>(
+    default_priority: i32,
+) -> impl FnOnce(IncompleteInitializerConfig<T>) -> InitializerConfig<T> {
+    move |IncompleteInitializerConfig { common, custom }| InitializerConfig {
+        common: CommonConfig {
+            enable: common.enable,
+            priority: common.priority.unwrap_or(default_priority),
+        },
+        custom,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::Value;
+    use crate::util::test_util::TestCase;
+    use insta::assert_toml_snapshot;
+    use rstest::{fixture, rstest};
 
-    #[test]
+    #[fixture]
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn custom_config() {
-        // Note: since we're parsing into a Initializer config struct directly, we don't
-        // need to prefix `foo` with `initializer`. If we want to actually provide custom initializer
-        // configs, the table key will need to be `[initializer.foo]`.
-        let config = r#"
+    fn case() -> TestCase {
+        Default::default()
+    }
+
+    #[rstest]
+    #[case("")]
+    #[case(
+        r#"
+        [normalize-path]
+        enable = false
+        "#
+    )]
+    #[case(
+        r#"
+        [normalize-path]
+        priority = 1234
+        "#
+    )]
+    #[case(
+        r#"
+        default-enable = false
+        "#
+    )]
+    #[case(
+        r#"
+        default-enable = false
+        [normalize-path]
+        enable = false
+        priority = 1234
+        "#
+    )]
+    #[case(
+        r#"
         [foo]
         enable = true
         priority = 10
         x = "y"
-        "#;
-        let config: Initializer = toml::from_str(config).unwrap();
+        "#
+    )]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn initializer(_case: TestCase, #[case] config: &str) {
+        let initializer: Initializer = toml::from_str(config).unwrap();
 
-        assert!(config.custom.contains_key("foo"));
-
-        let config = config.custom.get("foo").unwrap();
-        assert_eq!(config.common.enable, Some(true));
-        assert_eq!(config.common.priority, 10);
-
-        assert!(config.custom.config.contains_key("x"));
-        let x = config.custom.config.get("x").unwrap();
-        assert_eq!(x, &Value::String("y".to_string()));
+        assert_toml_snapshot!(initializer);
     }
 }

--- a/src/config/service/http/middleware.rs
+++ b/src/config/service/http/middleware.rs
@@ -11,6 +11,8 @@ use crate::service::http::middleware::sensitive_headers::{
 use crate::service::http::middleware::size_limit::SizeLimitConfig;
 use crate::service::http::middleware::timeout::TimeoutConfig;
 use crate::service::http::middleware::tracing::TracingConfig;
+use crate::util::serde_util;
+use crate::util::serde_util::default_true;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use validator::Validate;
@@ -21,16 +23,61 @@ pub const PRIORITY_LAST: i32 = 10_000;
 #[derive(Debug, Clone, Validate, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default)]
 pub struct Middleware {
+    #[serde(default = "default_true")]
     pub default_enable: bool,
+
+    #[serde(
+        deserialize_with = "deserialize_sensitive_request_headers",
+        default = "default_sensitive_request_headers"
+    )]
     pub sensitive_request_headers: MiddlewareConfig<SensitiveRequestHeadersConfig>,
+
+    #[serde(
+        deserialize_with = "deserialize_sensitive_response_headers",
+        default = "default_sensitive_response_headers"
+    )]
     pub sensitive_response_headers: MiddlewareConfig<SensitiveResponseHeadersConfig>,
+
+    #[serde(
+        deserialize_with = "deserialize_set_request_id",
+        default = "default_set_request_id"
+    )]
     pub set_request_id: MiddlewareConfig<SetRequestIdConfig>,
+
+    #[serde(
+        deserialize_with = "deserialize_propagate_request_id",
+        default = "default_propagate_request_id"
+    )]
     pub propagate_request_id: MiddlewareConfig<PropagateRequestIdConfig>,
+
+    #[serde(deserialize_with = "deserialize_tracing", default = "default_tracing")]
     pub tracing: MiddlewareConfig<TracingConfig>,
+
+    #[serde(
+        deserialize_with = "deserialize_catch_panic",
+        default = "default_catch_panic"
+    )]
     pub catch_panic: MiddlewareConfig<CatchPanicConfig>,
+
+    #[serde(
+        deserialize_with = "deserialize_response_compression",
+        default = "default_response_compression"
+    )]
     pub response_compression: MiddlewareConfig<ResponseCompressionConfig>,
+
+    #[serde(
+        deserialize_with = "deserialize_request_decompression",
+        default = "default_request_decompression"
+    )]
     pub request_decompression: MiddlewareConfig<RequestDecompressionConfig>,
+
+    #[serde(deserialize_with = "deserialize_timeout", default = "default_timeout")]
     pub timeout: MiddlewareConfig<TimeoutConfig>,
+
+    #[serde(
+        deserialize_with = "deserialize_size_limit",
+        default = "default_size_limit"
+    )]
     pub size_limit: MiddlewareConfig<SizeLimitConfig>,
     /// Allows providing configs for custom middleware. Any configs that aren't pre-defined above
     /// will be collected here.
@@ -66,78 +113,36 @@ pub struct Middleware {
 
 impl Default for Middleware {
     fn default() -> Self {
-        // Before request middlewares
-        let mut priority = PRIORITY_FIRST;
-        let sensitive_request_headers: MiddlewareConfig<SensitiveRequestHeadersConfig> =
-            Default::default();
-        let sensitive_request_headers = sensitive_request_headers.set_priority(priority);
-
-        priority += 10;
-        let set_request_id: MiddlewareConfig<SetRequestIdConfig> = Default::default();
-        let set_request_id = set_request_id.set_priority(priority);
-
-        priority += 10;
-        let tracing: MiddlewareConfig<TracingConfig> = Default::default();
-        let tracing = tracing.set_priority(priority);
-
-        priority += 10;
-        let size_limit: MiddlewareConfig<SizeLimitConfig> = Default::default();
-        let size_limit = size_limit.set_priority(priority);
-
-        priority += 10;
-        let request_decompression: MiddlewareConfig<RequestDecompressionConfig> =
-            Default::default();
-        let request_decompression = request_decompression.set_priority(priority);
-
-        // Somewhere in the middle, order doesn't particularly matter
-        let catch_panic: MiddlewareConfig<CatchPanicConfig> = Default::default();
-        let response_compression: MiddlewareConfig<ResponseCompressionConfig> = Default::default();
-        let timeout: MiddlewareConfig<TimeoutConfig> = Default::default();
-
-        // Before response middlewares
-        let mut priority = PRIORITY_LAST;
-        let sensitive_response_headers: MiddlewareConfig<SensitiveResponseHeadersConfig> =
-            Default::default();
-        let sensitive_response_headers = sensitive_response_headers.set_priority(priority);
-
-        priority -= 10;
-        let propagate_request_id: MiddlewareConfig<PropagateRequestIdConfig> = Default::default();
-        let propagate_request_id = propagate_request_id.set_priority(priority);
-
         Self {
-            default_enable: true,
-            sensitive_request_headers,
-            sensitive_response_headers,
-            set_request_id,
-            propagate_request_id,
-            tracing,
-            catch_panic,
-            response_compression,
-            request_decompression,
-            timeout,
-            size_limit,
+            default_enable: default_true(),
+            sensitive_request_headers: default_sensitive_request_headers(),
+            sensitive_response_headers: default_sensitive_response_headers(),
+            set_request_id: default_set_request_id(),
+            propagate_request_id: default_propagate_request_id(),
+            tracing: default_tracing(),
+            catch_panic: default_catch_panic(),
+            response_compression: default_response_compression(),
+            request_decompression: default_request_decompression(),
+            timeout: default_timeout(),
+            size_limit: default_size_limit(),
             custom: Default::default(),
         }
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case", default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct CommonConfig {
     // Optional so we can tell the difference between a consumer explicitly enabling/disabling
     // the middleware, vs the middleware being enabled/disabled by default.
     // If this is `None`, the value will match the value of `Middleware#default_enable`.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub enable: Option<bool>,
     pub priority: i32,
 }
 
 impl CommonConfig {
-    pub fn set_priority(mut self, priority: i32) -> Self {
-        self.priority = priority;
-        self
-    }
-
     pub fn enabled<S>(&self, context: &AppContext<S>) -> bool {
         self.enable.unwrap_or(
             context
@@ -151,19 +156,253 @@ impl CommonConfig {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case", default)]
-pub struct MiddlewareConfig<T: Default> {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct MiddlewareConfig<T> {
     #[serde(flatten)]
     pub common: CommonConfig,
     #[serde(flatten)]
     pub custom: T,
 }
 
-impl<T: Default> MiddlewareConfig<T> {
-    pub fn set_priority(mut self, priority: i32) -> Self {
-        self.common = self.common.set_priority(priority);
-        self
+// This fun boilerplate allows the user to
+// 1. Partially override a config without needing to provide all of the required values for the config
+// 2. Prevent a type's `Default` implementation from being used and overriding the default we
+//    actually want. For example, we provide a default for the `priority` fields, and we want that
+//    value to be used if the user doesn't provide one, not the type's default (`0` in this case).
+//
+// See: https://users.rust-lang.org/t/serde-default-value-for-struct-field-depending-on-parent/73452/2
+//
+// This is mainly needed because all of the middleware share a struct for their common configs,
+// so we can't simply set a default on the field directly with a serde annotation.
+// An alternative implementation could be to have different structs for each middleware's common
+// config instead of sharing a struct type. However, that would still require a lot of boilerplate.
+
+struct Priorities {
+    sensitive_request_headers: i32,
+    sensitive_response_headers: i32,
+    set_request_id: i32,
+    propagate_request_id: i32,
+    tracing: i32,
+    catch_panic: i32,
+    response_compression: i32,
+    request_decompression: i32,
+    timeout: i32,
+    size_limit: i32,
+}
+
+impl Default for Priorities {
+    fn default() -> Self {
+        let mut priority = PRIORITY_FIRST;
+        let sensitive_request_headers = priority;
+
+        priority += 10;
+        let set_request_id = priority;
+
+        priority += 10;
+        let tracing = priority;
+
+        priority += 10;
+        let size_limit = priority;
+
+        priority += 10;
+        let request_decompression = priority;
+
+        // Somewhere in the middle, order doesn't particularly matter
+        let catch_panic = 0;
+        let response_compression = 0;
+        let timeout = 0;
+
+        // Before response middlewares
+        let mut priority = PRIORITY_LAST;
+        let sensitive_response_headers = priority;
+
+        priority -= 10;
+        let propagate_request_id = priority;
+
+        Self {
+            sensitive_request_headers,
+            set_request_id,
+            tracing,
+            size_limit,
+            request_decompression,
+            catch_panic,
+            response_compression,
+            timeout,
+            sensitive_response_headers,
+            propagate_request_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct PartialCommonConfig {
+    pub enable: Option<bool>,
+    pub priority: Option<i32>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct IncompleteMiddlewareConfig<T> {
+    #[serde(flatten)]
+    pub common: PartialCommonConfig,
+    #[serde(flatten)]
+    pub custom: T,
+}
+
+fn deserialize_sensitive_request_headers<'de, D, T>(
+    deserializer: D,
+) -> Result<MiddlewareConfig<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(deserializer).map(map_empty_config(
+        Priorities::default().sensitive_request_headers,
+    ))
+}
+
+fn default_sensitive_request_headers() -> MiddlewareConfig<SensitiveRequestHeadersConfig> {
+    deserialize_sensitive_request_headers(serde_util::empty_json_object()).unwrap()
+}
+
+fn deserialize_sensitive_response_headers<'de, D, T>(
+    deserializer: D,
+) -> Result<MiddlewareConfig<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(deserializer).map(map_empty_config(
+        Priorities::default().sensitive_response_headers,
+    ))
+}
+
+fn default_sensitive_response_headers() -> MiddlewareConfig<SensitiveResponseHeadersConfig> {
+    deserialize_sensitive_response_headers(serde_util::empty_json_object()).unwrap()
+}
+
+fn deserialize_set_request_id<'de, D, T>(deserializer: D) -> Result<MiddlewareConfig<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(deserializer)
+        .map(map_empty_config(Priorities::default().set_request_id))
+}
+
+fn default_set_request_id() -> MiddlewareConfig<SetRequestIdConfig> {
+    deserialize_set_request_id(serde_util::empty_json_object()).unwrap()
+}
+
+fn deserialize_propagate_request_id<'de, D, T>(
+    deserializer: D,
+) -> Result<MiddlewareConfig<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(deserializer)
+        .map(map_empty_config(Priorities::default().propagate_request_id))
+}
+
+fn default_propagate_request_id() -> MiddlewareConfig<PropagateRequestIdConfig> {
+    deserialize_propagate_request_id(serde_util::empty_json_object()).unwrap()
+}
+
+fn deserialize_tracing<'de, D, T>(deserializer: D) -> Result<MiddlewareConfig<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(deserializer)
+        .map(map_empty_config(Priorities::default().tracing))
+}
+
+fn default_tracing() -> MiddlewareConfig<TracingConfig> {
+    deserialize_tracing(serde_util::empty_json_object()).unwrap()
+}
+
+fn deserialize_catch_panic<'de, D, T>(deserializer: D) -> Result<MiddlewareConfig<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(deserializer)
+        .map(map_empty_config(Priorities::default().catch_panic))
+}
+
+fn default_catch_panic() -> MiddlewareConfig<CatchPanicConfig> {
+    deserialize_catch_panic(serde_util::empty_json_object()).unwrap()
+}
+
+fn deserialize_response_compression<'de, D, T>(
+    deserializer: D,
+) -> Result<MiddlewareConfig<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(deserializer)
+        .map(map_empty_config(Priorities::default().response_compression))
+}
+
+fn default_response_compression() -> MiddlewareConfig<ResponseCompressionConfig> {
+    deserialize_response_compression(serde_util::empty_json_object()).unwrap()
+}
+
+fn deserialize_request_decompression<'de, D, T>(
+    deserializer: D,
+) -> Result<MiddlewareConfig<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(deserializer).map(map_empty_config(
+        Priorities::default().request_decompression,
+    ))
+}
+
+fn default_request_decompression() -> MiddlewareConfig<RequestDecompressionConfig> {
+    deserialize_request_decompression(serde_util::empty_json_object()).unwrap()
+}
+
+fn deserialize_timeout<'de, D, T>(deserializer: D) -> Result<MiddlewareConfig<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(deserializer)
+        .map(map_empty_config(Priorities::default().timeout))
+}
+
+fn default_timeout() -> MiddlewareConfig<TimeoutConfig> {
+    deserialize_timeout(serde_util::empty_json_object()).unwrap()
+}
+
+fn deserialize_size_limit<'de, D, T>(deserializer: D) -> Result<MiddlewareConfig<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(deserializer)
+        .map(map_empty_config(Priorities::default().size_limit))
+}
+
+fn default_size_limit() -> MiddlewareConfig<SizeLimitConfig> {
+    deserialize_size_limit(serde_util::empty_json_object()).unwrap()
+}
+
+fn map_empty_config<T>(
+    default_priority: i32,
+) -> impl FnOnce(IncompleteMiddlewareConfig<T>) -> MiddlewareConfig<T> {
+    move |IncompleteMiddlewareConfig { common, custom }| MiddlewareConfig {
+        common: CommonConfig {
+            enable: common.enable,
+            priority: common.priority.unwrap_or(default_priority),
+        },
+        custom,
     }
 }
 
@@ -172,7 +411,6 @@ mod tests {
     use super::*;
     use crate::config::app_config::AppConfig;
     use rstest::rstest;
-    use serde_json::Value;
 
     #[rstest]
     #[case(true, None, true)]
@@ -195,35 +433,90 @@ mod tests {
 
         let common_config = CommonConfig {
             enable,
-            ..Default::default()
+            priority: 0,
         };
 
         // Act/Assert
         assert_eq!(common_config.enabled(&context), expected_enabled);
     }
+}
 
-    #[test]
+#[cfg(test)]
+mod deserialize_tests {
+    use super::*;
+    use crate::util::test_util::TestCase;
+    use insta::assert_toml_snapshot;
+    use rstest::{fixture, rstest};
+
+    #[fixture]
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn custom_config() {
-        // Note: since we're parsing into a Middleware config struct directly, we don't
-        // need to prefix `foo` with `middleware`. If we want to actually provide custom middleware
-        // configs, the table key will need to be `[middleware.foo]`.
-        let config = r#"
+    fn case() -> TestCase {
+        Default::default()
+    }
+
+    #[rstest]
+    #[case("")]
+    #[case(
+        r#"
+        [sensitive-request-headers]
+        enable = false
+        [sensitive-response-headers]
+        enable = false
+        [set-request-id]
+        enable = false
+        [propagate-request-id]
+        enable = false
+        [tracing]
+        enable = false
+        [catch-panic]
+        enable = false
+        [response-compression]
+        enable = false
+        [request-decompression]
+        enable = false
+        [timeout]
+        enable = false
+        [size-limit]
+        enable = false
+        "#
+    )]
+    #[case(
+        r#"
+        default-enable = false
+        [sensitive-request-headers]
+        priority = -1
+        [sensitive-response-headers]
+        priority = 0
+        [set-request-id]
+        priority = 1
+        [propagate-request-id]
+        priority = 2
+        [tracing]
+        priority = 3
+        [catch-panic]
+        priority = 4
+        [response-compression]
+        priority = 5
+        [request-decompression]
+        priority = 6
+        [timeout]
+        priority = 7
+        [size-limit]
+        priority = 8
+        "#
+    )]
+    #[case(
+        r#"
         [foo]
         enable = true
         priority = 10
         x = "y"
-        "#;
-        let config: Middleware = toml::from_str(config).unwrap();
+        "#
+    )]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn middleware(_case: TestCase, #[case] config: &str) {
+        let middleware: Middleware = toml::from_str(config).unwrap();
 
-        assert!(config.custom.contains_key("foo"));
-
-        let config = config.custom.get("foo").unwrap();
-        assert_eq!(config.common.enable, Some(true));
-        assert_eq!(config.common.priority, 10);
-
-        assert!(config.custom.config.contains_key("x"));
-        let x = config.custom.config.get("x").unwrap();
-        assert_eq!(x, &Value::String("y".to_string()));
+        assert_toml_snapshot!(middleware);
     }
 }

--- a/src/config/service/http/mod.rs
+++ b/src/config/service/http/mod.rs
@@ -1,10 +1,10 @@
-use crate::app_context::AppContext;
 use crate::config::service::http::initializer::Initializer;
 use crate::config::service::http::middleware::Middleware;
-use crate::util::serde_util::default_true;
+use default_routes::DefaultRoutes;
 use serde_derive::{Deserialize, Serialize};
-use validator::{Validate, ValidationError};
+use validator::Validate;
 
+pub mod default_routes;
 pub mod initializer;
 pub mod middleware;
 
@@ -35,134 +35,5 @@ pub struct Address {
 impl Address {
     pub fn url(&self) -> String {
         format!("{}:{}", self.host, self.port)
-    }
-}
-
-#[derive(Debug, Clone, Default, Validate, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-#[validate(schema(function = "validate_default_routes"))]
-pub struct DefaultRoutes {
-    #[serde(default = "default_true")]
-    pub default_enable: bool,
-    #[serde(default)]
-    pub ping: DefaultRouteConfig,
-    #[serde(default)]
-    pub health: DefaultRouteConfig,
-    #[cfg(feature = "open-api")]
-    #[serde(default)]
-    pub api_schema: DefaultRouteConfig,
-    #[cfg(feature = "open-api")]
-    #[serde(default)]
-    pub scalar: DefaultRouteConfig,
-    #[cfg(feature = "open-api")]
-    #[serde(default)]
-    pub redoc: DefaultRouteConfig,
-}
-
-fn validate_default_routes(
-    // This parameter isn't used for some feature flag combinations
-    #[allow(unused)] default_routes: &DefaultRoutes,
-) -> Result<(), ValidationError> {
-    #[cfg(feature = "open-api")]
-    {
-        let default_enable = default_routes.default_enable;
-        let api_schema_enabled = default_routes.api_schema.enable.unwrap_or(default_enable);
-        let scalar_enabled = default_routes.scalar.enable.unwrap_or(default_enable);
-        let redoc_enabled = default_routes.redoc.enable.unwrap_or(default_enable);
-
-        if scalar_enabled && !api_schema_enabled {
-            return Err(ValidationError::new(
-                "The Open API schema route must be enabled in order to use the Scalar docs route.",
-            ));
-        }
-        if redoc_enabled && !api_schema_enabled {
-            return Err(ValidationError::new(
-                "The Open API schema route must be enabled in order to use the Redoc docs route.",
-            ));
-        }
-    }
-
-    Ok(())
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub struct DefaultRouteConfig {
-    pub enable: Option<bool>,
-    pub route: Option<String>,
-}
-
-impl DefaultRouteConfig {
-    pub fn enabled<S>(&self, context: &AppContext<S>) -> bool {
-        self.enable.unwrap_or(
-            context
-                .config()
-                .service
-                .http
-                .custom
-                .default_routes
-                .default_enable,
-        )
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use rstest::rstest;
-
-    #[rstest]
-    #[case(false, false)]
-    #[case(true, false)]
-    #[cfg(not(feature = "open-api"))]
-    #[cfg_attr(coverage_nightly, coverage(off))]
-    fn validate_default_routes(#[case] default_enable: bool, #[case] validation_error: bool) {
-        // Arrange
-        #[allow(clippy::field_reassign_with_default)]
-        let config = {
-            let mut config = DefaultRoutes::default();
-            config.default_enable = default_enable;
-            config
-        };
-
-        // Act
-        let result = config.validate();
-
-        // Assert
-        assert_eq!(result.is_err(), validation_error);
-    }
-
-    #[rstest]
-    #[case(false, None, None, None, false)]
-    #[case(true, None, None, None, false)]
-    #[case(false, None, Some(true), None, true)]
-    #[case(false, None, None, Some(true), true)]
-    #[case(false, Some(true), Some(true), None, false)]
-    #[case(false, Some(true), None, Some(true), false)]
-    #[cfg(feature = "open-api")]
-    #[cfg_attr(coverage_nightly, coverage(off))]
-    fn validate_default_routes(
-        #[case] default_enable: bool,
-        #[case] api_schema_enabled: Option<bool>,
-        #[case] scalar_enabled: Option<bool>,
-        #[case] redoc_enabled: Option<bool>,
-        #[case] validation_error: bool,
-    ) {
-        // Arrange
-        #[allow(clippy::field_reassign_with_default)]
-        let config = {
-            let mut config = DefaultRoutes::default();
-            config.default_enable = default_enable;
-            config.api_schema.enable = api_schema_enabled;
-            config.scalar.enable = scalar_enabled;
-            config.redoc.enable = redoc_enabled;
-            config
-        };
-
-        // Act
-        let result = config.validate();
-
-        // Assert
-        assert_eq!(result.is_err(), validation_error);
     }
 }

--- a/src/config/service/http/snapshots/roadster__config__service__http__default_routes__deserialize_tests__auth@case_1.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__default_routes__deserialize_tests__auth@case_1.snap
@@ -1,0 +1,20 @@
+---
+source: src/config/service/http/default_routes.rs
+expression: default_routes
+---
+default-enable = true
+
+[ping]
+route = '_ping'
+
+[health]
+route = '_health'
+
+[api-schema]
+route = '_docs/api.json'
+
+[scalar]
+route = '_docs'
+
+[redoc]
+route = '_docs/redoc'

--- a/src/config/service/http/snapshots/roadster__config__service__http__default_routes__deserialize_tests__auth@case_2.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__default_routes__deserialize_tests__auth@case_2.snap
@@ -1,0 +1,25 @@
+---
+source: src/config/service/http/default_routes.rs
+expression: default_routes
+---
+default-enable = false
+
+[ping]
+enable = true
+route = '_ping'
+
+[health]
+enable = true
+route = '_health'
+
+[api-schema]
+enable = true
+route = '_docs/api.json'
+
+[scalar]
+enable = true
+route = '_docs'
+
+[redoc]
+enable = true
+route = '_docs/redoc'

--- a/src/config/service/http/snapshots/roadster__config__service__http__default_routes__deserialize_tests__auth@case_3.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__default_routes__deserialize_tests__auth@case_3.snap
@@ -1,0 +1,25 @@
+---
+source: src/config/service/http/default_routes.rs
+expression: default_routes
+---
+default-enable = false
+
+[ping]
+enable = false
+route = '_ping'
+
+[health]
+enable = false
+route = '_health'
+
+[api-schema]
+enable = false
+route = '_docs/api.json'
+
+[scalar]
+enable = false
+route = '_docs'
+
+[redoc]
+enable = false
+route = '_docs/redoc'

--- a/src/config/service/http/snapshots/roadster__config__service__http__default_routes__deserialize_tests__auth@case_4.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__default_routes__deserialize_tests__auth@case_4.snap
@@ -1,0 +1,20 @@
+---
+source: src/config/service/http/default_routes.rs
+expression: default_routes
+---
+default-enable = false
+
+[ping]
+route = 'a'
+
+[health]
+route = 'b'
+
+[api-schema]
+route = 'c'
+
+[scalar]
+route = 'd'
+
+[redoc]
+route = 'e'

--- a/src/config/service/http/snapshots/roadster__config__service__http__default_routes__deserialize_tests__auth@case_5.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__default_routes__deserialize_tests__auth@case_5.snap
@@ -1,0 +1,25 @@
+---
+source: src/config/service/http/default_routes.rs
+expression: default_routes
+---
+default-enable = true
+
+[ping]
+enable = true
+route = 'a'
+
+[health]
+enable = true
+route = 'b'
+
+[api-schema]
+enable = true
+route = 'c'
+
+[scalar]
+enable = true
+route = 'd'
+
+[redoc]
+enable = true
+route = 'e'

--- a/src/config/service/http/snapshots/roadster__config__service__http__initializer__tests__initializer@case_1.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__initializer__tests__initializer@case_1.snap
@@ -1,0 +1,8 @@
+---
+source: src/config/service/http/initializer.rs
+expression: initializer
+---
+default-enable = true
+
+[normalize-path]
+priority = 10000

--- a/src/config/service/http/snapshots/roadster__config__service__http__initializer__tests__initializer@case_2.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__initializer__tests__initializer@case_2.snap
@@ -1,0 +1,9 @@
+---
+source: src/config/service/http/initializer.rs
+expression: initializer
+---
+default-enable = true
+
+[normalize-path]
+enable = false
+priority = 10000

--- a/src/config/service/http/snapshots/roadster__config__service__http__initializer__tests__initializer@case_3.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__initializer__tests__initializer@case_3.snap
@@ -1,0 +1,8 @@
+---
+source: src/config/service/http/initializer.rs
+expression: initializer
+---
+default-enable = true
+
+[normalize-path]
+priority = 1234

--- a/src/config/service/http/snapshots/roadster__config__service__http__initializer__tests__initializer@case_4.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__initializer__tests__initializer@case_4.snap
@@ -1,0 +1,8 @@
+---
+source: src/config/service/http/initializer.rs
+expression: initializer
+---
+default-enable = false
+
+[normalize-path]
+priority = 10000

--- a/src/config/service/http/snapshots/roadster__config__service__http__initializer__tests__initializer@case_5.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__initializer__tests__initializer@case_5.snap
@@ -1,0 +1,9 @@
+---
+source: src/config/service/http/initializer.rs
+expression: initializer
+---
+default-enable = false
+
+[normalize-path]
+enable = false
+priority = 1234

--- a/src/config/service/http/snapshots/roadster__config__service__http__initializer__tests__initializer@case_6.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__initializer__tests__initializer@case_6.snap
@@ -1,0 +1,13 @@
+---
+source: src/config/service/http/initializer.rs
+expression: initializer
+---
+default-enable = true
+
+[normalize-path]
+priority = 10000
+
+[foo]
+enable = true
+priority = 10
+x = 'y'

--- a/src/config/service/http/snapshots/roadster__config__service__http__middleware__deserialize_tests__middleware@case_1.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__middleware__deserialize_tests__middleware@case_1.snap
@@ -1,0 +1,51 @@
+---
+source: src/config/service/http/middleware.rs
+expression: middleware
+---
+default-enable = true
+
+[sensitive-request-headers]
+priority = -10000
+header-names = [
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+]
+
+[sensitive-response-headers]
+priority = 10000
+header-names = [
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+]
+
+[set-request-id]
+priority = -9990
+header-name = 'request-id'
+
+[propagate-request-id]
+priority = 9990
+header-name = 'request-id'
+
+[tracing]
+priority = -9980
+
+[catch-panic]
+priority = 0
+
+[response-compression]
+priority = 0
+
+[request-decompression]
+priority = -9960
+
+[timeout]
+priority = 0
+timeout = 10000
+
+[size-limit]
+priority = -9970
+limit = '5 MB'

--- a/src/config/service/http/snapshots/roadster__config__service__http__middleware__deserialize_tests__middleware@case_2.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__middleware__deserialize_tests__middleware@case_2.snap
@@ -1,0 +1,61 @@
+---
+source: src/config/service/http/middleware.rs
+expression: middleware
+---
+default-enable = true
+
+[sensitive-request-headers]
+enable = false
+priority = -10000
+header-names = [
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+]
+
+[sensitive-response-headers]
+enable = false
+priority = 10000
+header-names = [
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+]
+
+[set-request-id]
+enable = false
+priority = -9990
+header-name = 'request-id'
+
+[propagate-request-id]
+enable = false
+priority = 9990
+header-name = 'request-id'
+
+[tracing]
+enable = false
+priority = -9980
+
+[catch-panic]
+enable = false
+priority = 0
+
+[response-compression]
+enable = false
+priority = 0
+
+[request-decompression]
+enable = false
+priority = -9960
+
+[timeout]
+enable = false
+priority = 0
+timeout = 10000
+
+[size-limit]
+enable = false
+priority = -9970
+limit = '5 MB'

--- a/src/config/service/http/snapshots/roadster__config__service__http__middleware__deserialize_tests__middleware@case_3.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__middleware__deserialize_tests__middleware@case_3.snap
@@ -1,0 +1,51 @@
+---
+source: src/config/service/http/middleware.rs
+expression: middleware
+---
+default-enable = false
+
+[sensitive-request-headers]
+priority = -1
+header-names = [
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+]
+
+[sensitive-response-headers]
+priority = 0
+header-names = [
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+]
+
+[set-request-id]
+priority = 1
+header-name = 'request-id'
+
+[propagate-request-id]
+priority = 2
+header-name = 'request-id'
+
+[tracing]
+priority = 3
+
+[catch-panic]
+priority = 4
+
+[response-compression]
+priority = 5
+
+[request-decompression]
+priority = 6
+
+[timeout]
+priority = 7
+timeout = 10000
+
+[size-limit]
+priority = 8
+limit = '5 MB'

--- a/src/config/service/http/snapshots/roadster__config__service__http__middleware__deserialize_tests__middleware@case_4.snap
+++ b/src/config/service/http/snapshots/roadster__config__service__http__middleware__deserialize_tests__middleware@case_4.snap
@@ -1,0 +1,56 @@
+---
+source: src/config/service/http/middleware.rs
+expression: middleware
+---
+default-enable = true
+
+[sensitive-request-headers]
+priority = -10000
+header-names = [
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+]
+
+[sensitive-response-headers]
+priority = 10000
+header-names = [
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+]
+
+[set-request-id]
+priority = -9990
+header-name = 'request-id'
+
+[propagate-request-id]
+priority = 9990
+header-name = 'request-id'
+
+[tracing]
+priority = -9980
+
+[catch-panic]
+priority = 0
+
+[response-compression]
+priority = 0
+
+[request-decompression]
+priority = -9960
+
+[timeout]
+priority = 0
+timeout = 10000
+
+[size-limit]
+priority = -9970
+limit = '5 MB'
+
+[foo]
+enable = true
+priority = 10
+x = 'y'

--- a/src/config/service/worker/sidekiq/snapshots/roadster__config__service__worker__sidekiq__deserialize_tests__sidekiq@case_1.snap
+++ b/src/config/service/worker/sidekiq/snapshots/roadster__config__service__worker__sidekiq__deserialize_tests__sidekiq@case_1.snap
@@ -1,0 +1,22 @@
+---
+source: src/config/service/worker/sidekiq/mod.rs
+expression: sidekiq
+---
+num-workers = 1
+queues = []
+
+[redis]
+uri = 'redis://localhost:6379'
+
+[redis.enqueue-pool]
+
+[redis.fetch-pool]
+
+[periodic]
+stale-cleanup = 'auto-clean-stale'
+
+[app-worker]
+max-retries = 5
+timeout = true
+max-duration = 60
+disable-argument-coercion = false

--- a/src/config/service/worker/sidekiq/snapshots/roadster__config__service__worker__sidekiq__deserialize_tests__sidekiq@case_2.snap
+++ b/src/config/service/worker/sidekiq/snapshots/roadster__config__service__worker__sidekiq__deserialize_tests__sidekiq@case_2.snap
@@ -1,0 +1,22 @@
+---
+source: src/config/service/worker/sidekiq/mod.rs
+expression: sidekiq
+---
+num-workers = 1
+queues = []
+
+[redis]
+uri = 'redis://localhost:6379'
+
+[redis.enqueue-pool]
+
+[redis.fetch-pool]
+
+[periodic]
+stale-cleanup = 'auto-clean-stale'
+
+[app-worker]
+max-retries = 5
+timeout = true
+max-duration = 60
+disable-argument-coercion = false

--- a/src/config/service/worker/sidekiq/snapshots/roadster__config__service__worker__sidekiq__deserialize_tests__sidekiq@case_3.snap
+++ b/src/config/service/worker/sidekiq/snapshots/roadster__config__service__worker__sidekiq__deserialize_tests__sidekiq@case_3.snap
@@ -1,0 +1,22 @@
+---
+source: src/config/service/worker/sidekiq/mod.rs
+expression: sidekiq
+---
+num-workers = 1
+queues = ['foo']
+
+[redis]
+uri = 'redis://localhost:6379'
+
+[redis.enqueue-pool]
+
+[redis.fetch-pool]
+
+[periodic]
+stale-cleanup = 'auto-clean-stale'
+
+[app-worker]
+max-retries = 5
+timeout = true
+max-duration = 60
+disable-argument-coercion = false

--- a/src/config/service/worker/sidekiq/snapshots/roadster__config__service__worker__sidekiq__deserialize_tests__sidekiq@case_4.snap
+++ b/src/config/service/worker/sidekiq/snapshots/roadster__config__service__worker__sidekiq__deserialize_tests__sidekiq@case_4.snap
@@ -1,0 +1,24 @@
+---
+source: src/config/service/worker/sidekiq/mod.rs
+expression: sidekiq
+---
+num-workers = 1
+queues = []
+
+[redis]
+uri = 'redis://localhost:6379'
+
+[redis.enqueue-pool]
+min-idle = 1
+
+[redis.fetch-pool]
+min-idle = 2
+
+[periodic]
+stale-cleanup = 'auto-clean-stale'
+
+[app-worker]
+max-retries = 5
+timeout = true
+max-duration = 60
+disable-argument-coercion = false

--- a/src/config/service/worker/sidekiq/snapshots/roadster__config__service__worker__sidekiq__deserialize_tests__sidekiq@case_5.snap
+++ b/src/config/service/worker/sidekiq/snapshots/roadster__config__service__worker__sidekiq__deserialize_tests__sidekiq@case_5.snap
@@ -1,0 +1,24 @@
+---
+source: src/config/service/worker/sidekiq/mod.rs
+expression: sidekiq
+---
+num-workers = 1
+queues = []
+
+[redis]
+uri = 'redis://localhost:6379'
+
+[redis.enqueue-pool]
+max-connections = 1
+
+[redis.fetch-pool]
+max-connections = 2
+
+[periodic]
+stale-cleanup = 'auto-clean-stale'
+
+[app-worker]
+max-retries = 5
+timeout = true
+max-duration = 60
+disable-argument-coercion = false

--- a/src/config/service/worker/sidekiq/snapshots/roadster__config__service__worker__sidekiq__deserialize_tests__sidekiq@case_6.snap
+++ b/src/config/service/worker/sidekiq/snapshots/roadster__config__service__worker__sidekiq__deserialize_tests__sidekiq@case_6.snap
@@ -1,0 +1,22 @@
+---
+source: src/config/service/worker/sidekiq/mod.rs
+expression: sidekiq
+---
+num-workers = 1
+queues = []
+
+[redis]
+uri = 'redis://localhost:6379'
+
+[redis.enqueue-pool]
+
+[redis.fetch-pool]
+
+[periodic]
+stale-cleanup = 'auto-clean-stale'
+
+[app-worker]
+max-retries = 5
+timeout = true
+max-duration = 60
+disable-argument-coercion = false

--- a/src/config/snapshots/roadster__config__database__deserialize_tests__sidekiq@case_1.snap
+++ b/src/config/snapshots/roadster__config__database__deserialize_tests__sidekiq@case_1.snap
@@ -1,0 +1,10 @@
+---
+source: src/config/database.rs
+expression: database
+---
+uri = 'https://example.com:1234/'
+auto-migrate = true
+connect-timeout = 1000
+acquire-timeout = 1000
+min-connections = 0
+max-connections = 1

--- a/src/config/snapshots/roadster__config__database__deserialize_tests__sidekiq@case_2.snap
+++ b/src/config/snapshots/roadster__config__database__deserialize_tests__sidekiq@case_2.snap
@@ -1,0 +1,12 @@
+---
+source: src/config/database.rs
+expression: database
+---
+uri = 'https://example.com:1234/'
+auto-migrate = true
+connect-timeout = 1000
+acquire-timeout = 2000
+idle-timeout = 3000
+max-lifetime = 4000
+min-connections = 0
+max-connections = 1

--- a/src/config/snapshots/roadster__config__tracing__deserialize_tests__sidekiq@case_1.snap
+++ b/src/config/snapshots/roadster__config__tracing__deserialize_tests__sidekiq@case_1.snap
@@ -1,0 +1,6 @@
+---
+source: src/config/tracing.rs
+expression: tracing
+---
+level = 'debug'
+trace-propagation = true

--- a/src/config/snapshots/roadster__config__tracing__deserialize_tests__sidekiq@case_2.snap
+++ b/src/config/snapshots/roadster__config__tracing__deserialize_tests__sidekiq@case_2.snap
@@ -1,0 +1,7 @@
+---
+source: src/config/tracing.rs
+expression: tracing
+---
+level = 'info'
+service-name = 'foo'
+trace-propagation = true

--- a/src/config/snapshots/roadster__config__tracing__deserialize_tests__sidekiq@case_3.snap
+++ b/src/config/snapshots/roadster__config__tracing__deserialize_tests__sidekiq@case_3.snap
@@ -1,0 +1,6 @@
+---
+source: src/config/tracing.rs
+expression: tracing
+---
+level = 'error'
+trace-propagation = false

--- a/src/config/snapshots/roadster__config__tracing__deserialize_tests__sidekiq@case_4.snap
+++ b/src/config/snapshots/roadster__config__tracing__deserialize_tests__sidekiq@case_4.snap
@@ -1,0 +1,7 @@
+---
+source: src/config/tracing.rs
+expression: tracing
+---
+level = 'debug'
+trace-propagation = true
+otlp-endpoint = 'https://example.com:1234/'

--- a/src/config/tracing.rs
+++ b/src/config/tracing.rs
@@ -1,0 +1,72 @@
+#[cfg(feature = "otel")]
+use crate::util::serde_util::default_true;
+use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "otel")]
+use url::Url;
+use validator::Validate;
+
+#[derive(Debug, Clone, Validate, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Tracing {
+    pub level: String,
+
+    /// The name of the service to use for the OpenTelemetry `service.name` field. If not provided,
+    /// will use the [`App::name`][crate::config::app_config::App] config value, translated to `snake_case`.
+    #[cfg(feature = "otel")]
+    pub service_name: Option<String>,
+
+    /// Propagate traces across service boundaries. Mostly useful in microservice architectures.
+    #[serde(default = "default_true")]
+    #[cfg(feature = "otel")]
+    pub trace_propagation: bool,
+
+    /// URI of the OTLP exporter where traces/metrics/logs will be sent.
+    #[cfg(feature = "otel")]
+    pub otlp_endpoint: Option<Url>,
+}
+
+// To simplify testing, these are only run when all of the config fields are available
+#[cfg(all(test, feature = "otel"))]
+mod deserialize_tests {
+    use super::*;
+    use crate::util::test_util::TestCase;
+    use insta::assert_toml_snapshot;
+    use rstest::{fixture, rstest};
+
+    #[fixture]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn case() -> TestCase {
+        Default::default()
+    }
+
+    #[rstest]
+    #[case(
+        r#"
+        level = "debug"
+        "#
+    )]
+    #[case(
+        r#"
+        level = "info"
+        service-name = "foo"
+        "#
+    )]
+    #[case(
+        r#"
+        level = "error"
+        trace-propagation = false
+        "#
+    )]
+    #[case(
+        r#"
+        level = "debug"
+        otlp-endpoint = "https://example.com:1234"
+        "#
+    )]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn sidekiq(_case: TestCase, #[case] config: &str) {
+        let tracing: Tracing = toml::from_str(config).unwrap();
+
+        assert_toml_snapshot!(tracing);
+    }
+}

--- a/src/controller/http/ping.rs
+++ b/src/controller/http/ping.rs
@@ -1,5 +1,4 @@
 use crate::app_context::AppContext;
-use crate::config::app_config::AppConfig;
 use crate::controller::http::build_path;
 use crate::view::http::app_error::AppError;
 #[cfg(feature = "open-api")]
@@ -27,7 +26,7 @@ where
     if !enabled(context) {
         return router;
     }
-    let root = build_path(parent, &route(context));
+    let root = build_path(parent, route(context));
     router.route(&root, get(ping_get))
 }
 
@@ -40,7 +39,7 @@ where
     if !enabled(context) {
         return router;
     }
-    let root = build_path(parent, &route(context));
+    let root = build_path(parent, route(context));
     router.api_route(&root, get_with(ping_get, ping_get_docs))
 }
 
@@ -55,17 +54,15 @@ fn enabled<S>(context: &AppContext<S>) -> bool {
         .enabled(context)
 }
 
-fn route<S>(context: &AppContext<S>) -> String {
-    let config: &AppConfig = context.config();
-    config
+fn route<S>(context: &AppContext<S>) -> &str {
+    &context
+        .config()
         .service
         .http
         .custom
         .default_routes
         .ping
         .route
-        .clone()
-        .unwrap_or_else(|| "_ping".to_string())
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -108,14 +105,16 @@ mod tests {
         let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.default_routes.default_enable = default_enable;
         config.service.http.custom.default_routes.ping.enable = enable;
-        config
-            .service
-            .http
-            .custom
-            .default_routes
-            .ping
-            .route
-            .clone_from(&route);
+        if let Some(route) = route.as_ref() {
+            config
+                .service
+                .http
+                .custom
+                .default_routes
+                .ping
+                .route
+                .clone_from(route);
+        }
         let context = AppContext::<()>::test(Some(config), None).unwrap();
 
         assert_eq!(super::enabled(&context), enabled);

--- a/src/service/worker/sidekiq/snapshots/roadster__service__worker__sidekiq__app_worker__deserialize_tests__app_worker@case_1.snap
+++ b/src/service/worker/sidekiq/snapshots/roadster__service__worker__sidekiq__app_worker__deserialize_tests__app_worker@case_1.snap
@@ -1,0 +1,8 @@
+---
+source: src/service/worker/sidekiq/app_worker.rs
+expression: app_worker
+---
+max-retries = 5
+timeout = true
+max-duration = 60
+disable-argument-coercion = false

--- a/src/service/worker/sidekiq/snapshots/roadster__service__worker__sidekiq__app_worker__deserialize_tests__app_worker@case_2.snap
+++ b/src/service/worker/sidekiq/snapshots/roadster__service__worker__sidekiq__app_worker__deserialize_tests__app_worker@case_2.snap
@@ -1,0 +1,8 @@
+---
+source: src/service/worker/sidekiq/app_worker.rs
+expression: app_worker
+---
+max-retries = 1
+timeout = true
+max-duration = 60
+disable-argument-coercion = false

--- a/src/service/worker/sidekiq/snapshots/roadster__service__worker__sidekiq__app_worker__deserialize_tests__app_worker@case_3.snap
+++ b/src/service/worker/sidekiq/snapshots/roadster__service__worker__sidekiq__app_worker__deserialize_tests__app_worker@case_3.snap
@@ -1,0 +1,8 @@
+---
+source: src/service/worker/sidekiq/app_worker.rs
+expression: app_worker
+---
+max-retries = 5
+timeout = false
+max-duration = 60
+disable-argument-coercion = false

--- a/src/service/worker/sidekiq/snapshots/roadster__service__worker__sidekiq__app_worker__deserialize_tests__app_worker@case_4.snap
+++ b/src/service/worker/sidekiq/snapshots/roadster__service__worker__sidekiq__app_worker__deserialize_tests__app_worker@case_4.snap
@@ -1,0 +1,8 @@
+---
+source: src/service/worker/sidekiq/app_worker.rs
+expression: app_worker
+---
+max-retries = 5
+timeout = true
+max-duration = 1234
+disable-argument-coercion = false

--- a/src/service/worker/sidekiq/snapshots/roadster__service__worker__sidekiq__app_worker__deserialize_tests__app_worker@case_5.snap
+++ b/src/service/worker/sidekiq/snapshots/roadster__service__worker__sidekiq__app_worker__deserialize_tests__app_worker@case_5.snap
@@ -1,0 +1,8 @@
+---
+source: src/service/worker/sidekiq/app_worker.rs
+expression: app_worker
+---
+max-retries = 5
+timeout = true
+max-duration = 60
+disable-argument-coercion = true

--- a/src/util/serde_util.rs
+++ b/src/util/serde_util.rs
@@ -1,8 +1,10 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
+use serde::de::IntoDeserializer;
 use serde::{de, Deserializer, Serializer};
 use serde_derive::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use url::Url;
 
 /// Custom deserializer to allow deserializing a string field as the given type `T`, as long as
@@ -50,8 +52,14 @@ impl Display for UriOrString {
 }
 
 /// Function to default a boolean field to `true`.
-pub fn default_true() -> bool {
+pub const fn default_true() -> bool {
     true
+}
+
+// This method isn't used for some feature combinations
+#[allow(dead_code)]
+pub(crate) fn empty_json_object() -> impl for<'de> Deserializer<'de> {
+    Value::Object(Map::new()).into_deserializer()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The app config defines defaults for a lot of things. However, if the user provides a field, sometimes that means the defaults for the rest of that sub-config don’t use the default and need to be set by the user. This is especially difficult to work around for fields that re-use the same struct.

Refactor how the app config fields that share a common struct are contructed to provide a different default for each use of the struct, while still allowing the user to partially override individual fields of the config.

Also, add tests for all (most?) of the app config to ensure this behavior is not broken in the future.

Closes https://github.com/roadster-rs/roadster/issues/152