### PR TITLE
Add latest version of `time` to workaround build issue on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,9 @@ log = "0.4.21"
 futures = "0.3.30"
 validator = { version = "0.18.1", features = ["derive"] }
 thiserror = "1.0.61"
+# Add latest version of `time` to resolve a build error on nightly
+# https://github.com/time-rs/time/issues/681
+time = "0.3.36"
 
 [dev-dependencies]
 cargo-husky = { version = "1.5.0", default-features = false, features = ["user-hooks"] }


### PR DESCRIPTION
We don’t currently need a direct dependency on `time`, but the version being pulled in currently is failing to build on nightly.