### PR TITLE
Revert "Use stable rust for coverage"

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,9 +17,9 @@ jobs:
       RUSTFLAGS: -D warnings -A unexpected_cfgs
       CARGO_TERM_COLOR: always
     steps:
-      # - uses: dtolnay/rust-toolchain@nightly
-      #   with:
-      #     components: llvm-tools-preview
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: llvm-tools-preview
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
@@ -29,7 +29,8 @@ jobs:
         # Generate coverage report using nextest.
         run: |
           cargo llvm-cov --no-report nextest --all-features
-          cargo llvm-cov report --lcov --output-path lcov.info
+          cargo llvm-cov --no-report --doc --all-features
+          cargo llvm-cov report --doctests --lcov --output-path lcov.info
       - name: Upload coverage data to codecov
         uses: codecov/codecov-action@v4
         env:


### PR DESCRIPTION
This reverts commit 6ab77d03135417a13da16ced6ca91d49de4c7a8f.