### PR TITLE
Enable grpc by default in the `full` example

### DIFF
--- a/examples/full/Cargo.toml
+++ b/examples/full/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["grpc"]
 grpc = ["roadster/grpc", "dep:tonic", "dep:tonic-reflection", "dep:prost"]
 
 [dependencies]


### PR DESCRIPTION
Without this, JetBrains IDEs on linux (at least) don't seem to be able to resolve the protobuf-generated rust files.