### PR TITLE
feat: Move sidekiq "stale cleanup" to new `before_run` service method

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -89,6 +89,8 @@ where
         A::M::up(context.db(), None).await?;
     }
 
+    crate::service::runner::before_run(&service_registry, &context).await?;
+
     crate::service::runner::run(service_registry, &context).await?;
 
     Ok(())

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -46,6 +46,14 @@ pub trait AppService<A: App + 'static>: Send + Sync {
         Ok(false)
     }
 
+    /// Perform any initialization work or other checks that should be done before the service runs.
+    ///
+    /// For example, checking that the service is healthy, removing stale items from the
+    /// service's queue, etc.
+    async fn before_run(&self, _app_context: &AppContext<A::State>) -> RoadsterResult<()> {
+        Ok(())
+    }
+
     /// Run the service in a new tokio task.
     ///
     /// * cancel_token - A tokio [CancellationToken] to use as a signal to gracefully shut down

--- a/src/service/runner.rs
+++ b/src/service/runner.rs
@@ -27,6 +27,21 @@ where
     Ok(false)
 }
 
+pub(crate) async fn before_run<A>(
+    service_registry: &ServiceRegistry<A>,
+    context: &AppContext<A::State>,
+) -> RoadsterResult<()>
+where
+    A: App,
+{
+    for (name, service) in service_registry.services.iter() {
+        info!(service=%name, "Running `before run`");
+        service.before_run(context).await?;
+    }
+
+    Ok(())
+}
+
 pub(crate) async fn run<A>(
     service_registry: ServiceRegistry<A>,
     context: &AppContext<A::State>,


### PR DESCRIPTION
In order to allow handling CLI commands with services without requiring the sidkiq redis connection to be available, we need to move the "stale cleanup" behavior out of the "build" method so that the service can be built without needing to access redis.

This is accomplished by adding a new `AppService::before_run` trait method, which is run after all the services are built and before any of the services are run. The sidekiq service's "stale cleanup" behavior is now implemented in this trait method.

This PR also updates the health check API to run the db and redis checks in parallel.

Closes https://github.com/roadster-rs/roadster/issues/238