### PR TITLE
feat: Add `From` impl to convert db config to ConnectOptions

### DIFF
--- a/src/config/database/snapshots/roadster__config__database__deserialize_tests__db_config_to_connect_options.snap
+++ b/src/config/database/snapshots/roadster__config__database__deserialize_tests__db_config_to_connect_options.snap
@@ -1,0 +1,32 @@
+---
+source: src/config/database/mod.rs
+expression: connect_options
+---
+ConnectOptions {
+    url: "postgres://example:example@example:1234/example_app",
+    max_connections: Some(
+        20,
+    ),
+    min_connections: Some(
+        10,
+    ),
+    connect_timeout: Some(
+        1s,
+    ),
+    idle_timeout: Some(
+        3s,
+    ),
+    acquire_timeout: Some(
+        2s,
+    ),
+    max_lifetime: Some(
+        4s,
+    ),
+    sqlx_logging: false,
+    sqlx_logging_level: Info,
+    sqlx_slow_statements_logging_level: Off,
+    sqlx_slow_statements_logging_threshold: 1s,
+    sqlcipher_key: None,
+    schema_search_path: None,
+    test_before_acquire: true,
+}


### PR DESCRIPTION
Add `From<Database>` impl for `ConnectOptions` to encapsulate the conversion, which would make it easier if a consumer wants to override the default `App#db_connection_options` method but keep some of our defaults.