### PR TITLE
feat: Add health checks to run before starting services

### DIFF
--- a/src/api/core/health.rs
+++ b/src/api/core/health.rs
@@ -81,19 +81,19 @@ where
     let timer = Instant::now();
 
     #[cfg(any(feature = "db-sql", feature = "sidekiq"))]
-    let timeout_duration = Duration::from_secs(1);
+    let timeout_duration = Some(Duration::from_secs(1));
 
     #[cfg(all(feature = "db-sql", feature = "sidekiq"))]
     let (db, (redis_enqueue, redis_fetch)) = tokio::join!(
         db_health(state, timeout_duration),
-        all_redis_health(state, timeout_duration)
+        all_sidekiq_redis_health(state, timeout_duration)
     );
 
     #[cfg(all(feature = "db-sql", not(feature = "sidekiq")))]
     let db = db_health(state, timeout_duration).await;
 
     #[cfg(all(not(feature = "db-sql"), feature = "sidekiq"))]
-    let (redis_enqueue, redis_fetch) = all_redis_health(state, timeout_duration).await;
+    let (redis_enqueue, redis_fetch) = all_sidekiq_redis_health(state, timeout_duration).await;
 
     Ok(HeathCheckResponse {
         latency: timer.elapsed().as_millis(),
@@ -107,7 +107,10 @@ where
 }
 
 #[cfg(feature = "db-sql")]
-pub(crate) async fn db_health<S>(state: &AppContext<S>, duration: Duration) -> ResourceHealth
+pub(crate) async fn db_health<S>(
+    state: &AppContext<S>,
+    duration: Option<Duration>,
+) -> ResourceHealth
 where
     S: Clone + Send + Sync + 'static,
 {
@@ -129,15 +132,19 @@ where
 
 #[cfg(feature = "db-sql")]
 #[instrument(skip_all)]
-async fn ping_db(db: &DatabaseConnection, duration: Duration) -> RoadsterResult<()> {
-    timeout(duration, db.ping()).await??;
+async fn ping_db(db: &DatabaseConnection, duration: Option<Duration>) -> RoadsterResult<()> {
+    if let Some(duration) = duration {
+        timeout(duration, db.ping()).await??;
+    } else {
+        db.ping().await?;
+    }
     Ok(())
 }
 
 #[cfg(feature = "sidekiq")]
-pub(crate) async fn all_redis_health<S>(
+pub(crate) async fn all_sidekiq_redis_health<S>(
     state: &AppContext<S>,
-    duration: Duration,
+    duration: Option<Duration>,
 ) -> (ResourceHealth, Option<ResourceHealth>)
 where
     S: Clone + Send + Sync + 'static,
@@ -156,7 +163,7 @@ where
 
 #[cfg(feature = "sidekiq")]
 #[instrument(skip_all)]
-async fn redis_health(redis: &sidekiq::RedisPool, duration: Duration) -> ResourceHealth {
+async fn redis_health(redis: &sidekiq::RedisPool, duration: Option<Duration>) -> ResourceHealth {
     let redis_timer = Instant::now();
     let (redis_status, acquire_conn_latency, ping_latency) = match ping_redis(redis, duration).await
     {
@@ -182,10 +189,14 @@ async fn redis_health(redis: &sidekiq::RedisPool, duration: Duration) -> Resourc
 #[instrument(skip_all)]
 async fn ping_redis(
     redis: &sidekiq::RedisPool,
-    duration: Duration,
+    duration: Option<Duration>,
 ) -> RoadsterResult<(Duration, Duration)> {
     let timer = Instant::now();
-    let mut conn = timeout(duration, redis.get()).await??;
+    let mut conn = if let Some(duration) = duration {
+        timeout(duration, redis.get()).await??
+    } else {
+        redis.get().await?
+    };
     let acquire_conn_latency = timer.elapsed();
 
     let timer = Instant::now();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -89,6 +89,8 @@ where
         A::M::up(context.db(), None).await?;
     }
 
+    crate::service::runner::health_checks(&service_registry, &context).await?;
+
     crate::service::runner::before_run(&service_registry, &context).await?;
 
     crate::service::runner::run(service_registry, &context).await?;

--- a/src/config/app_config.rs
+++ b/src/config/app_config.rs
@@ -2,6 +2,7 @@ use crate::config::auth::Auth;
 #[cfg(feature = "db-sql")]
 use crate::config::database::Database;
 use crate::config::environment::{Environment, ENVIRONMENT_ENV_VAR_NAME};
+use crate::config::health_check::HealthCheck;
 use crate::config::service::Service;
 use crate::config::tracing::Tracing;
 use crate::error::RoadsterResult;
@@ -24,6 +25,8 @@ pub struct AppConfig {
     pub environment: Environment,
     #[validate(nested)]
     pub app: App,
+    #[validate(nested)]
+    pub health_check: HealthCheck,
     #[validate(nested)]
     pub service: Service,
     #[validate(nested)]
@@ -167,6 +170,8 @@ impl AppConfig {
 
         #[cfg(feature = "sidekiq")]
         let config = config.add_source(crate::config::service::worker::sidekiq::default_config());
+
+        let config = config.add_source(crate::config::health_check::default_config());
 
         config
     }

--- a/src/config/default.toml
+++ b/src/config/default.toml
@@ -3,3 +3,6 @@ shutdown-on-error = true
 
 [service]
 default-enable = true
+
+[health-check]
+default-enable = true

--- a/src/config/health_check/default.toml
+++ b/src/config/health_check/default.toml
@@ -1,0 +1,3 @@
+[health-check.database]
+
+[health-check.sidekiq]

--- a/src/config/health_check/mod.rs
+++ b/src/config/health_check/mod.rs
@@ -48,3 +48,35 @@ pub struct HealthCheckConfig<T> {
     #[serde(flatten)]
     pub custom: T,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::app_config::AppConfig;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(true, None, true)]
+    #[case(true, Some(true), true)]
+    #[case(true, Some(false), false)]
+    #[case(false, None, false)]
+    #[case(false, Some(true), true)]
+    #[case(false, Some(false), false)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn common_config_enabled(
+        #[case] default_enable: bool,
+        #[case] enable: Option<bool>,
+        #[case] expected_enabled: bool,
+    ) {
+        // Arrange
+        let mut config = AppConfig::test(None).unwrap();
+        config.health_check.default_enable = default_enable;
+
+        let context = AppContext::<()>::test(Some(config), None, None).unwrap();
+
+        let common_config = CommonConfig { enable };
+
+        // Act/Assert
+        assert_eq!(common_config.enabled(&context), expected_enabled);
+    }
+}

--- a/src/config/health_check/mod.rs
+++ b/src/config/health_check/mod.rs
@@ -1,0 +1,50 @@
+use crate::app::context::AppContext;
+use crate::util::serde_util::default_true;
+use config::{FileFormat, FileSourceString};
+use serde_derive::{Deserialize, Serialize};
+use validator::Validate;
+
+pub fn default_config() -> config::File<FileSourceString, FileFormat> {
+    config::File::from_str(include_str!("default.toml"), FileFormat::Toml)
+}
+
+#[derive(Debug, Clone, Validate, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub struct HealthCheck {
+    #[serde(default = "default_true")]
+    pub default_enable: bool,
+    #[cfg(feature = "db-sql")]
+    pub database: HealthCheckConfig<()>,
+    #[cfg(feature = "sidekiq")]
+    pub sidekiq: HealthCheckConfig<()>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub struct CommonConfig {
+    // Optional so we can tell the difference between a consumer explicitly enabling/disabling
+    // the health check, vs the health check being enabled/disabled by default.
+    // If this is `None`, the value will match the value of `HealthCheck#default_enable`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub enable: Option<bool>,
+}
+
+impl CommonConfig {
+    pub fn enabled<S>(&self, context: &AppContext<S>) -> bool {
+        self.enable
+            .unwrap_or(context.config().health_check.default_enable)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub struct HealthCheckConfig<T> {
+    #[serde(flatten)]
+    pub common: CommonConfig,
+    #[serde(flatten)]
+    pub custom: T,
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,5 +3,6 @@ pub mod auth;
 #[cfg(feature = "db-sql")]
 pub mod database;
 pub mod environment;
+pub mod health_check;
 pub mod service;
 pub mod tracing;

--- a/src/config/snapshots/roadster__config__app_config__tests__test.snap
+++ b/src/config/snapshots/roadster__config__app_config__tests__test.snap
@@ -8,6 +8,13 @@ environment = 'test'
 name = 'Test'
 shutdown-on-error = true
 
+[health-check]
+default-enable = true
+
+[health-check.database]
+
+[health-check.sidekiq]
+
 [service]
 default-enable = true
 

--- a/src/health_check/database.rs
+++ b/src/health_check/database.rs
@@ -16,12 +16,7 @@ impl<A: App + 'static> HealthCheck<A> for DatabaseHealthCheck {
     }
 
     fn enabled(&self, context: &AppContext<A::State>) -> bool {
-        context
-            .config()
-            .health_check
-            .database
-            .common
-            .enabled(context)
+        enabled(context)
     }
 
     #[instrument(skip_all)]
@@ -33,5 +28,41 @@ impl<A: App + 'static> HealthCheck<A> for DatabaseHealthCheck {
         }
 
         Ok(())
+    }
+}
+
+fn enabled<S>(context: &AppContext<S>) -> bool {
+    context
+        .config()
+        .health_check
+        .database
+        .common
+        .enabled(context)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::app_config::AppConfig;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(false, Some(true), true)]
+    #[case(false, Some(false), false)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn enabled(
+        #[case] default_enable: bool,
+        #[case] enable: Option<bool>,
+        #[case] expected_enabled: bool,
+    ) {
+        // Arrange
+        let mut config = AppConfig::test(None).unwrap();
+        config.health_check.default_enable = default_enable;
+        config.health_check.database.common.enable = enable;
+
+        let context = AppContext::<()>::test(Some(config), None, None).unwrap();
+
+        // Act/Assert
+        assert_eq!(super::enabled(&context), expected_enabled);
     }
 }

--- a/src/health_check/database.rs
+++ b/src/health_check/database.rs
@@ -1,0 +1,37 @@
+use crate::api::core::health::{db_health, Status};
+use crate::app::context::AppContext;
+use crate::app::App;
+use crate::error::RoadsterResult;
+use crate::health_check::HealthCheck;
+use anyhow::anyhow;
+use async_trait::async_trait;
+use tracing::instrument;
+
+pub struct DatabaseHealthCheck;
+
+#[async_trait]
+impl<A: App + 'static> HealthCheck<A> for DatabaseHealthCheck {
+    fn name(&self) -> String {
+        "db".to_string()
+    }
+
+    fn enabled(&self, context: &AppContext<A::State>) -> bool {
+        context
+            .config()
+            .health_check
+            .database
+            .common
+            .enabled(context)
+    }
+
+    #[instrument(skip_all)]
+    async fn check(&self, app_context: &AppContext<A::State>) -> RoadsterResult<()> {
+        let health = db_health(app_context, None).await;
+
+        if let Status::Err(err) = health.status {
+            return Err(anyhow!("Database connection pool is not healthy: {:?}", err).into());
+        }
+
+        Ok(())
+    }
+}

--- a/src/health_check/default.rs
+++ b/src/health_check/default.rs
@@ -1,0 +1,24 @@
+use crate::app::context::AppContext;
+use crate::app::App;
+#[cfg(feature = "db-sql")]
+use crate::health_check::database::DatabaseHealthCheck;
+#[cfg(feature = "sidekiq")]
+use crate::health_check::sidekiq::SidekiqHealthCheck;
+use crate::health_check::HealthCheck;
+use std::collections::BTreeMap;
+
+pub fn default_health_checks<A: App + 'static>(
+    context: &AppContext<A::State>,
+) -> BTreeMap<String, Box<dyn HealthCheck<A>>> {
+    let health_check: Vec<Box<dyn HealthCheck<A>>> = vec![
+        #[cfg(feature = "db-sql")]
+        Box::new(DatabaseHealthCheck),
+        #[cfg(feature = "sidekiq")]
+        Box::new(SidekiqHealthCheck),
+    ];
+    health_check
+        .into_iter()
+        .filter(|health_check| health_check.enabled(context))
+        .map(|health_check| (health_check.name(), health_check))
+        .collect()
+}

--- a/src/health_check/default.rs
+++ b/src/health_check/default.rs
@@ -22,3 +22,39 @@ pub fn default_health_checks<A: App + 'static>(
         .map(|health_check| (health_check.name(), health_check))
         .collect()
 }
+
+#[cfg(all(test, feature = "sidekiq", feature = "db-sql",))]
+mod tests {
+    use crate::app::context::AppContext;
+    use crate::app::MockApp;
+    use crate::config::app_config::AppConfig;
+    use crate::util::test_util::TestCase;
+    use insta::assert_toml_snapshot;
+    use itertools::Itertools;
+    use rstest::{fixture, rstest};
+
+    #[fixture]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn case() -> TestCase {
+        Default::default()
+    }
+
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn default_middleware(_case: TestCase, #[case] default_enable: bool) {
+        // Arrange
+        let mut config = AppConfig::test(None).unwrap();
+        config.health_check.default_enable = default_enable;
+
+        let context = AppContext::<()>::test(Some(config), None, None).unwrap();
+
+        // Act
+        let health_checks = super::default_health_checks::<MockApp>(&context);
+        let health_checks = health_checks.keys().collect_vec();
+
+        // Assert
+        assert_toml_snapshot!(health_checks);
+    }
+}

--- a/src/health_check/mod.rs
+++ b/src/health_check/mod.rs
@@ -1,0 +1,37 @@
+#[cfg(feature = "db-sql")]
+pub mod database;
+pub mod default;
+#[cfg(feature = "sidekiq")]
+pub mod sidekiq;
+
+use crate::app::context::AppContext;
+use crate::app::App;
+use crate::error::RoadsterResult;
+use async_trait::async_trait;
+
+/// Trait used to check the health of the app before its services start up.
+///
+/// This is a separate trait, vs adding a "health check" method to `AppService`, to allow defining
+/// health checks that apply to multiple services. For example, most services would require
+/// the DB and Redis connections to be valid, so we would want to perform a check for these
+/// resources a single time before starting any service instead of once for every service that
+/// needs the resources.
+///
+/// Another benefit of using a separate trait is, because the health checks are decoupled from
+/// services, they can potentially be used in other parts of the app. For example, they could
+/// be used to implement a "health check" API endpoint.
+// Todo: Use the `HealthCheck` trait to implement the "health check" api - https://github.com/roadster-rs/roadster/issues/241
+#[async_trait]
+#[cfg_attr(test, mockall::automock)]
+pub trait HealthCheck<A: App + 'static>: Send + Sync {
+    /// The name of the health check.
+    fn name(&self) -> String;
+
+    /// Whether the health check is enabled. If the health check is not enabled, Roadster will not
+    /// run it. However, if a consumer wants, they can certainly create a [HealthCheck] instance
+    /// and directly call `HealthCheck#check` even if `HealthCheck#enabled` returns `false`.
+    fn enabled(&self, context: &AppContext<A::State>) -> bool;
+
+    /// Run the health check.
+    async fn check(&self, app_context: &AppContext<A::State>) -> RoadsterResult<()>;
+}

--- a/src/health_check/sidekiq.rs
+++ b/src/health_check/sidekiq.rs
@@ -1,0 +1,50 @@
+use crate::api::core::health::{all_sidekiq_redis_health, Status};
+use crate::app::context::AppContext;
+use crate::app::App;
+use crate::error::RoadsterResult;
+use crate::health_check::HealthCheck;
+use anyhow::anyhow;
+use async_trait::async_trait;
+use tracing::instrument;
+
+pub struct SidekiqHealthCheck;
+
+#[async_trait]
+impl<A: App + 'static> HealthCheck<A> for SidekiqHealthCheck {
+    fn name(&self) -> String {
+        "sidekiq".to_string()
+    }
+
+    fn enabled(&self, context: &AppContext<A::State>) -> bool {
+        context
+            .config()
+            .health_check
+            .sidekiq
+            .common
+            .enabled(context)
+    }
+
+    #[instrument(skip_all)]
+    async fn check(&self, app_context: &AppContext<A::State>) -> RoadsterResult<()> {
+        let (redis_enqueue, redis_fetch) = all_sidekiq_redis_health(app_context, None).await;
+
+        if let Status::Err(err) = redis_enqueue.status {
+            return Err(anyhow!(
+                "Sidekiq redis enqueue connection pool is not healthy: {:?}",
+                err
+            )
+            .into());
+        }
+        if let Some(redis_fetch) = redis_fetch {
+            if let Status::Err(err) = redis_fetch.status {
+                return Err(anyhow!(
+                    "Sidekiq redis fetch connection pool is not healthy: {:?}",
+                    err
+                )
+                .into());
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/health_check/sidekiq.rs
+++ b/src/health_check/sidekiq.rs
@@ -16,12 +16,7 @@ impl<A: App + 'static> HealthCheck<A> for SidekiqHealthCheck {
     }
 
     fn enabled(&self, context: &AppContext<A::State>) -> bool {
-        context
-            .config()
-            .health_check
-            .sidekiq
-            .common
-            .enabled(context)
+        enabled(context)
     }
 
     #[instrument(skip_all)]
@@ -46,5 +41,41 @@ impl<A: App + 'static> HealthCheck<A> for SidekiqHealthCheck {
         }
 
         Ok(())
+    }
+}
+
+fn enabled<S>(context: &AppContext<S>) -> bool {
+    context
+        .config()
+        .health_check
+        .sidekiq
+        .common
+        .enabled(context)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::app_config::AppConfig;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(false, Some(true), true)]
+    #[case(false, Some(false), false)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn enabled(
+        #[case] default_enable: bool,
+        #[case] enable: Option<bool>,
+        #[case] expected_enabled: bool,
+    ) {
+        // Arrange
+        let mut config = AppConfig::test(None).unwrap();
+        config.health_check.default_enable = default_enable;
+        config.health_check.sidekiq.common.enable = enable;
+
+        let context = AppContext::<()>::test(Some(config), None, None).unwrap();
+
+        // Act/Assert
+        assert_eq!(super::enabled(&context), expected_enabled);
     }
 }

--- a/src/health_check/snapshots/roadster__health_check__default__tests__default_middleware@case_1.snap
+++ b/src/health_check/snapshots/roadster__health_check__default__tests__default_middleware@case_1.snap
@@ -1,0 +1,5 @@
+---
+source: src/health_check/default.rs
+expression: health_checks
+---
+[]

--- a/src/health_check/snapshots/roadster__health_check__default__tests__default_middleware@case_2.snap
+++ b/src/health_check/snapshots/roadster__health_check__default__tests__default_middleware@case_2.snap
@@ -1,0 +1,8 @@
+---
+source: src/health_check/default.rs
+expression: health_checks
+---
+[
+    'db',
+    'sidekiq',
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod api;
 pub mod app;
 pub mod config;
 pub mod error;
+pub mod health_check;
 pub mod middleware;
 pub mod service;
 pub mod tracing;

--- a/src/service/http/builder.rs
+++ b/src/service/http/builder.rs
@@ -191,7 +191,7 @@ impl<A: App> AppServiceBuilder<A, HttpService> for HttpServiceBuilder<A> {
             // Reverse due to how Axum's `Router#layer` method adds middleware.
             .rev()
             .try_fold(router, |router, middleware| {
-                info!(middleware=%middleware.name(), "Installing middleware");
+                info!(name=%middleware.name(), "Installing middleware");
                 middleware.install(router, context)
             })?;
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -22,11 +22,9 @@ pub mod worker;
 #[cfg_attr(test, mockall::automock)]
 pub trait AppService<A: App + 'static>: Send + Sync {
     /// The name of the service.
-    // todo: make this non-static? This would make some testing/mocking slightly easier
     fn name(&self) -> String;
 
     /// Whether the service is enabled. If the service is not enabled, it will not be run.
-    // todo: make this non-static? This would make some testing/mocking slightly easier
     fn enabled(&self, context: &AppContext<A::State>) -> bool;
 
     /// Called when the app is starting up allow the service to handle CLI commands.


### PR DESCRIPTION
This is a separate trait, vs adding a "health check" method to `AppService`, to allow defining health checks that apply to multiple services. For example, most services would require the DB and Redis connections to be valid, so we would want to perform a check for these resources a single time before starting any service instead of once for every service that needs the resources.

Another benefit of using a separate trait is, because the health checks are decoupled from services, they can potentially be used in other parts of the app. For example, they could be used to implement a "health check" API endpoint.

For now, I think it makes sense to register health checks on the `ServiceRegistry` since the checks are run right before running the services, and the checks need to succeed in order to run the services. In the future, it may make more sense to add a new method to the `App` trait in order to register health checks. In general, however, I'm trying to steer away from adding too many methods to the `App` trait.

Closes https://github.com/roadster-rs/roadster/issues/237