### PR TITLE
fix: Health check config is missing a `custom` field

### DIFF
--- a/src/config/health_check/mod.rs
+++ b/src/config/health_check/mod.rs
@@ -1,7 +1,9 @@
 use crate::app::context::AppContext;
+use crate::config::app_config::CustomConfig;
 use crate::util::serde_util::default_true;
 use config::{FileFormat, FileSourceString};
 use serde_derive::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use validator::Validate;
 
 pub fn default_config() -> config::File<FileSourceString, FileFormat> {
@@ -18,6 +20,33 @@ pub struct HealthCheck {
     pub database: HealthCheckConfig<()>,
     #[cfg(feature = "sidekiq")]
     pub sidekiq: HealthCheckConfig<()>,
+    /// Allows providing configs for custom health checks. Any configs that aren't pre-defined above
+    /// will be collected here.
+    ///
+    /// # Examples
+    ///
+    /// ```toml
+    /// [health-check.foo]
+    /// enable = true
+    /// x = "y"
+    /// ```
+    ///
+    /// This will be parsed as:
+    /// ```raw
+    /// HealthCheck#custom: {
+    ///     "foo": {
+    ///         HealthCheckConfig#common: {
+    ///             enable: true,
+    ///             priority: 10
+    ///         },
+    ///         HealthCheckConfig<CustomConfig>#custom: {
+    ///             "x": "y"
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    #[serde(flatten)]
+    pub custom: BTreeMap<String, HealthCheckConfig<CustomConfig>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/config/service/http/initializer.rs
+++ b/src/config/service/http/initializer.rs
@@ -38,9 +38,7 @@ pub struct Initializer {
     ///             priority: 10
     ///         },
     ///         InitializerConfig<CustomConfig>#custom: {
-    ///             config: {
-    ///                 "x": "y"
-    ///             }
+    ///             "x": "y"
     ///         }
     ///     }
     /// }

--- a/src/config/service/http/middleware.rs
+++ b/src/config/service/http/middleware.rs
@@ -70,9 +70,7 @@ pub struct Middleware {
     ///             priority: 10
     ///         },
     ///         MiddlewareConfig<CustomConfig>#custom: {
-    ///             config: {
-    ///                 "x": "y"
-    ///             }
+    ///             "x": "y"
     ///         }
     ///     }
     /// }


### PR DESCRIPTION
Similar to the middleware and initializer configs, we want to allow the consumer to access custom config options for their custom health checks.

This PR adds the `custom` field to the health check config.

Closes https://github.com/roadster-rs/roadster/issues/245