### PR TITLE
feat!: Switch to Axum's `FromRef` for custom state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.74.1"
 
 [features]
 default = ["sidekiq", "db-sql", "open-api", "jwt-ietf", "cli", "otel"]
-http = ["dep:axum", "dep:axum-extra", "dep:tower", "dep:tower-http"]
+http = ["dep:axum-extra", "dep:tower", "dep:tower-http"]
 open-api = ["http", "dep:aide", "dep:schemars"]
 sidekiq = ["dep:rusty-sidekiq", "dep:bb8", "dep:num_cpus"]
 db-sql = ["dep:sea-orm", "dep:sea-orm-migration"]
@@ -43,7 +43,9 @@ opentelemetry-otlp = { version = "0.16.0", features = ["metrics", "trace", "logs
 tracing-opentelemetry = { version = "0.24.0", features = ["metrics"], optional = true }
 
 # Controllers
-axum = { workspace = true, optional = true }
+# `axum` is not optional because we use the `FromRef` trait pretty extensively, even in parts of
+# the code that wouldn't otherwise need `axum`.
+axum = { workspace = true, features = ["macros"] }
 axum-extra = { version = "0.9.0", features = ["typed-header"], optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.5.0", features = ["trace", "timeout", "request-id", "util", "normalize-path", "sensitive-headers", "catch-panic", "compression-full", "decompression-full", "limit", "cors"], optional = true }

--- a/examples/full/src/app_state.rs
+++ b/examples/full/src/app_state.rs
@@ -1,5 +1,7 @@
+use axum::extract::FromRef;
 use roadster::app::context::AppContext;
 
-pub type CustomAppContext = ();
-
-pub type AppState = AppContext<CustomAppContext>;
+#[derive(Clone, FromRef)]
+pub struct AppState {
+    pub app_context: AppContext,
+}

--- a/examples/full/src/cli/mod.rs
+++ b/examples/full/src/cli/mod.rs
@@ -1,12 +1,9 @@
+use crate::app::App;
+use crate::app_state::AppState;
 use async_trait::async_trait;
 use clap::{Parser, Subcommand};
-use roadster::app::context::AppContext;
-
 use roadster::api::cli::RunCommand;
 use roadster::error::RoadsterResult;
-
-use crate::app::App;
-use crate::app_state::CustomAppContext;
 
 /// Full Example: Commands specific to managing the `full` app are provided in the CLI
 /// as well. Subcommands not listed under the `roadster` subcommand are specific to `full`.
@@ -19,16 +16,11 @@ pub struct AppCli {
 }
 
 #[async_trait]
-impl RunCommand<App> for AppCli {
+impl RunCommand<App, AppState> for AppCli {
     #[allow(clippy::disallowed_types)]
-    async fn run(
-        &self,
-        app: &App,
-        cli: &AppCli,
-        context: &AppContext<CustomAppContext>,
-    ) -> RoadsterResult<bool> {
+    async fn run(&self, app: &App, cli: &AppCli, state: &AppState) -> RoadsterResult<bool> {
         if let Some(command) = self.command.as_ref() {
-            command.run(app, cli, context).await
+            command.run(app, cli, state).await
         } else {
             Ok(false)
         }
@@ -42,13 +34,8 @@ impl RunCommand<App> for AppCli {
 pub enum AppCommand {}
 
 #[async_trait]
-impl RunCommand<App> for AppCommand {
-    async fn run(
-        &self,
-        _app: &App,
-        _cli: &AppCli,
-        _context: &AppContext<CustomAppContext>,
-    ) -> RoadsterResult<bool> {
+impl RunCommand<App, AppState> for AppCommand {
+    async fn run(&self, _app: &App, _cli: &AppCli, _state: &AppState) -> RoadsterResult<bool> {
         Ok(false)
     }
 }

--- a/examples/full/src/worker/example.rs
+++ b/examples/full/src/worker/example.rs
@@ -1,4 +1,3 @@
-use crate::app::App;
 use crate::app_state::AppState;
 use async_trait::async_trait;
 use roadster::service::worker::sidekiq::app_worker::AppWorker;
@@ -17,8 +16,8 @@ impl Worker<String> for ExampleWorker {
 }
 
 #[async_trait]
-impl AppWorker<App, String> for ExampleWorker {
-    fn build(_context: &AppState) -> Self {
+impl AppWorker<AppState, String> for ExampleWorker {
+    fn build(_state: &AppState) -> Self {
         Self {}
     }
 }

--- a/src/api/http/mod.rs
+++ b/src/api/http/mod.rs
@@ -1,6 +1,7 @@
 use crate::app::context::AppContext;
 #[cfg(feature = "open-api")]
 use aide::axum::ApiRouter;
+use axum::extract::FromRef;
 use axum::Router;
 use itertools::Itertools;
 
@@ -20,23 +21,25 @@ pub fn build_path(parent: &str, child: &str) -> String {
     path
 }
 
-pub fn default_routes<S>(parent: &str, context: &AppContext<S>) -> Router<AppContext<S>>
+pub fn default_routes<S>(parent: &str, state: &S) -> Router<S>
 where
     S: Clone + Send + Sync + 'static,
+    AppContext: FromRef<S>,
 {
     Router::new()
-        .merge(ping::routes(parent, context))
-        .merge(health::routes(parent, context))
+        .merge(ping::routes(parent, state))
+        .merge(health::routes(parent, state))
 }
 
 #[cfg(feature = "open-api")]
-pub fn default_api_routes<S>(parent: &str, context: &AppContext<S>) -> ApiRouter<AppContext<S>>
+pub fn default_api_routes<S>(parent: &str, state: &S) -> ApiRouter<S>
 where
     S: Clone + Send + Sync + 'static,
+    AppContext: FromRef<S>,
 {
     ApiRouter::new()
-        .merge(ping::api_routes(parent, context))
-        .merge(health::api_routes(parent, context))
+        .merge(ping::api_routes(parent, state))
+        .merge(health::api_routes(parent, state))
         // The docs route is only available when using Aide
-        .merge(docs::routes(parent, context))
+        .merge(docs::routes(parent, state))
 }

--- a/src/config/service/http/default_routes.rs
+++ b/src/config/service/http/default_routes.rs
@@ -1,5 +1,6 @@
 use crate::app::context::AppContext;
 use crate::util::serde_util::default_true;
+use axum::extract::FromRef;
 use serde_derive::{Deserialize, Serialize};
 use validator::Validate;
 use validator::ValidationError;
@@ -62,9 +63,13 @@ pub struct DefaultRouteConfig {
 }
 
 impl DefaultRouteConfig {
-    pub fn enabled<S>(&self, context: &AppContext<S>) -> bool {
+    pub fn enabled<S>(&self, state: &S) -> bool
+    where
+        S: Clone + Send + Sync + 'static,
+        AppContext: FromRef<S>,
+    {
         self.enable.unwrap_or(
-            context
+            AppContext::from_ref(state)
                 .config()
                 .service
                 .http

--- a/src/config/service/http/initializer.rs
+++ b/src/config/service/http/initializer.rs
@@ -2,6 +2,7 @@ use crate::app::context::AppContext;
 use crate::config::app_config::CustomConfig;
 use crate::service::http::initializer::normalize_path::NormalizePathConfig;
 use crate::util::serde_util::default_true;
+use axum::extract::FromRef;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use validator::Validate;
@@ -61,9 +62,13 @@ pub struct CommonConfig {
 }
 
 impl CommonConfig {
-    pub fn enabled<S>(&self, context: &AppContext<S>) -> bool {
+    pub fn enabled<S>(&self, state: &S) -> bool
+    where
+        S: Clone + Send + Sync + 'static,
+        AppContext: FromRef<S>,
+    {
         self.enable.unwrap_or(
-            context
+            AppContext::from_ref(state)
                 .config()
                 .service
                 .http

--- a/src/config/service/mod.rs
+++ b/src/config/service/mod.rs
@@ -48,7 +48,7 @@ pub struct CommonConfig {
 }
 
 impl CommonConfig {
-    pub fn enabled<T>(&self, context: &AppContext<T>) -> bool {
+    pub fn enabled(&self, context: &AppContext) -> bool {
         self.enable
             .unwrap_or(context.config().service.default_enable)
     }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -4,6 +4,7 @@ use crate::app::context::AppContext;
 use crate::app::App;
 use crate::error::RoadsterResult;
 use async_trait::async_trait;
+use axum::extract::FromRef;
 use tokio_util::sync::CancellationToken;
 
 pub mod function;
@@ -18,14 +19,20 @@ pub mod worker;
 /// Trait to represent a service (e.g., a persistent task) to run in the app. Example services
 /// include, but are not limited to: an [http API][crate::service::http::service::HttpService],
 /// a sidekiq processor, or a gRPC API.
-#[async_trait]
 #[cfg_attr(test, mockall::automock)]
-pub trait AppService<A: App + 'static>: Send + Sync {
+#[async_trait]
+pub trait AppService<A, S>: Send + Sync
+where
+    S: Clone + Send + Sync + 'static,
+    AppContext: FromRef<S>,
+    A: App<S> + 'static,
+{
     /// The name of the service.
     fn name(&self) -> String;
 
     /// Whether the service is enabled. If the service is not enabled, it will not be run.
-    fn enabled(&self, context: &AppContext<A::State>) -> bool;
+    // Todo: use AppContext directly?
+    fn enabled(&self, state: &S) -> bool;
 
     /// Called when the app is starting up allow the service to handle CLI commands.
     ///
@@ -39,7 +46,7 @@ pub trait AppService<A: App + 'static>: Send + Sync {
         &self,
         _roadster_cli: &RoadsterCli,
         _app_cli: &A::Cli,
-        _app_context: &AppContext<A::State>,
+        _state: &S,
     ) -> RoadsterResult<bool> {
         Ok(false)
     }
@@ -48,7 +55,7 @@ pub trait AppService<A: App + 'static>: Send + Sync {
     ///
     /// For example, checking that the service is healthy, removing stale items from the
     /// service's queue, etc.
-    async fn before_run(&self, _app_context: &AppContext<A::State>) -> RoadsterResult<()> {
+    async fn before_run(&self, _state: &S) -> RoadsterResult<()> {
         Ok(())
     }
 
@@ -56,11 +63,8 @@ pub trait AppService<A: App + 'static>: Send + Sync {
     ///
     /// * cancel_token - A tokio [CancellationToken] to use as a signal to gracefully shut down
     /// the service.
-    async fn run(
-        self: Box<Self>,
-        app_context: &AppContext<A::State>,
-        cancel_token: CancellationToken,
-    ) -> RoadsterResult<()>;
+    async fn run(self: Box<Self>, state: &S, cancel_token: CancellationToken)
+        -> RoadsterResult<()>;
 }
 
 /// Trait used to build an [AppService]. It's not a requirement that services implement this
@@ -68,16 +72,18 @@ pub trait AppService<A: App + 'static>: Send + Sync {
 /// the [ServiceRegistry][crate::service::registry::ServiceRegistry] instead of an [AppService],
 /// in which case the [ServiceRegistry][crate::service::registry::ServiceRegistry] will only
 /// build and register the service if [AppService::enabled] is `true`.
-#[async_trait]
 #[cfg_attr(test, mockall::automock)]
-pub trait AppServiceBuilder<A, S>
+#[async_trait]
+pub trait AppServiceBuilder<A, S, Service>
 where
-    A: App + 'static,
-    S: AppService<A>,
+    S: Clone + Send + Sync + 'static,
+    AppContext: FromRef<S>,
+    A: App<S> + 'static,
+    Service: AppService<A, S>,
 {
     fn name(&self) -> String;
 
-    fn enabled(&self, app_context: &AppContext<A::State>) -> bool;
+    fn enabled(&self, state: &S) -> bool;
 
-    async fn build(self, context: &AppContext<A::State>) -> RoadsterResult<S>;
+    async fn build(self, state: &S) -> RoadsterResult<Service>;
 }


### PR DESCRIPTION
Our previous approach to allowing consumers to provide custom
state/context was to embed it as a field in Roadster's `AppContext`.
This is not how Axum recommends libraries support custom state, which
makes it difficult (impossible?) to integrate Roadster with other
Axum libraries.

The recommended approach is to keep the state generic, and add a type
constraint to require Roadster's state to be able to be retrieved from
the custom state using the
[FromRef](https://docs.rs/axum/latest/axum/extract/derive.FromRef.html)
trait. See the following for more details: https://docs.rs/axum/latest/axum/extract/struct.State.html#for-library-authors

One example of an integration that was blocked by our non-recommended
approach: Leptos requires the app's state provide Leptos's state using
`FromRef`. In order to support Leptos with our previous approach, we
would have needed to add the Leptos state directly to Roadster's
`AppContext`. This adds a dependency on Roadster for consumers who may
want to use Leptos, and also adds a direct dependency between Roadster
and Leptos (though, it would be optional behind a feature flag). This
maybe could work in the short term, but this approach doesn't scale to
other libraries -- Roadster would need to follow a similar approach for
all other libraries consumers may want to use. Instead, it's better to
simply follow Axum's recommendation to provide maximum flexibility to
consumers.