### PR TITLE
chore!: Remove deprecated items in preparation of 0.4 release

### DIFF
--- a/src/api/http/health.rs
+++ b/src/api/http/health.rs
@@ -1,4 +1,6 @@
-use crate::api::core::health::{health_check, HeathCheckResponse, ResourceHealth, Status};
+use crate::api::core::health::{health_check, HeathCheckResponse};
+#[cfg(any(feature = "db-sql", feature = "sidekiq"))]
+use crate::api::core::health::{ResourceHealth, Status};
 use crate::api::http::build_path;
 use crate::app::context::AppContext;
 use crate::error::RoadsterResult;

--- a/src/api/http/health.rs
+++ b/src/api/http/health.rs
@@ -1,4 +1,4 @@
-use crate::api::core::health::health_check;
+use crate::api::core::health::{health_check, HeathCheckResponse, ResourceHealth, Status};
 use crate::api::http::build_path;
 use crate::app::context::AppContext;
 use crate::error::RoadsterResult;
@@ -13,12 +13,6 @@ use axum::extract::State;
 use axum::routing::get;
 use axum::{Json, Router};
 use tracing::instrument;
-
-#[deprecated(
-    since = "0.3.1",
-    note = "Please import from `roadster::api::core::health` instead."
-)]
-pub use crate::api::core::health::{ErrorData, HeathCheckResponse, ResourceHealth, Status};
 
 #[cfg(feature = "open-api")]
 const TAG: &str = "Health";

--- a/src/api/http/health.rs
+++ b/src/api/http/health.rs
@@ -1,5 +1,5 @@
 use crate::api::core::health::{health_check, HeathCheckResponse};
-#[cfg(any(feature = "db-sql", feature = "sidekiq"))]
+#[cfg(all(feature = "open-api", any(feature = "db-sql", feature = "sidekiq")))]
 use crate::api::core::health::{ResourceHealth, Status};
 use crate::api::http::build_path;
 use crate::app::context::AppContext;

--- a/src/config/app_config.rs
+++ b/src/config/app_config.rs
@@ -89,14 +89,6 @@ impl AppConfig {
                     .convert_case(Case::Kebab)
                     .separator(ENV_VAR_SEPARATOR),
             )
-            // This source is kept for backwards compatibility and may be removed in the next
-            // semver breaking release (0.4+)
-            .add_source(
-                config::Environment::default()
-                    .prefix(ENV_VAR_PREFIX)
-                    .convert_case(Case::Kebab)
-                    .separator("."),
-            )
             .set_override(ENVIRONMENT_ENV_VAR_NAME, environment_str)?
             .build()?;
         let config: AppConfig = config.try_deserialize()?;

--- a/src/config/environment.rs
+++ b/src/config/environment.rs
@@ -24,9 +24,6 @@ pub(crate) const ENVIRONMENT_ENV_VAR_NAME: &str = "ENVIRONMENT";
 
 const ENV_VAR_WITH_PREFIX: &str =
     concatcp!(ENV_VAR_PREFIX, ENV_VAR_SEPARATOR, ENVIRONMENT_ENV_VAR_NAME);
-// This env var is used for backwards compatibility and may be removed in the next
-// semver breaking release (0.4+)
-const ENV_VAR_WITH_PREFIX_OLD: &str = concatcp!(ENV_VAR_PREFIX, ".", ENVIRONMENT_ENV_VAR_NAME);
 
 impl Environment {
     // This runs before tracing is initialized, so we need to use `println` in order to
@@ -34,22 +31,14 @@ impl Environment {
     #[allow(clippy::disallowed_macros)]
     pub fn new() -> RoadsterResult<Self> {
         // Get the stage, and validate it by parsing to the Environment enum
-        let environment = if let Ok(value) = env::var(ENV_VAR_WITH_PREFIX) {
-            println!("Using environment from `{ENV_VAR_WITH_PREFIX}` env var: {value:?}");
-            value
-        } else if let Ok(value) = env::var(ENV_VAR_WITH_PREFIX_OLD) {
-            // This env var is used for backwards compatibility and may be removed in the next
-            // semver breaking release (0.4+)
-            println!("Using environment from `{ENV_VAR_WITH_PREFIX_OLD}` env var: {value:?}");
-            value
-        } else {
-            Err(anyhow!("Neither `{ENV_VAR_WITH_PREFIX}` nor `{ENV_VAR_WITH_PREFIX_OLD}` env vars are defined."))?;
-            unreachable!()
-        };
+        let environment = env::var(ENV_VAR_WITH_PREFIX)
+            .map_err(|_| anyhow!("Env var `{ENV_VAR_WITH_PREFIX}` not defined."))?;
         let environment = <Environment as FromStr>::from_str(&environment).map_err(|err| {
-            anyhow!("Unable to parse environment from env var value `{environment}`: {err}")
+            anyhow!(
+                "Unable to parse `{ENV_VAR_WITH_PREFIX}` env var with value `{environment}`: {err}"
+            )
         })?;
-        println!("Parsed environment from env var: {environment:?}");
+        println!("Using environment from `{ENV_VAR_WITH_PREFIX}` env var: {environment:?}");
         Ok(environment)
     }
 }


### PR DESCRIPTION
In preparation for the next semver breaking release, this PR removes some things:

- An export alias for health check structs that were moved
- Removes support for using `.` as the separate for in env var names