### PR TITLE
feat!: Remove interior mutability of `HealthCheckRegistry`

### DIFF
--- a/src/api/core/health.rs
+++ b/src/api/core/health.rs
@@ -53,7 +53,7 @@ where
     let context = AppContext::from_ref(state);
     let timer = Instant::now();
 
-    let check_futures = context.health_checks().checks()?.into_iter().map(|check| {
+    let check_futures = context.health_checks().into_iter().map(|check| {
         Box::pin(async move {
             let name = check.name();
             info!(name=%name, "Running check");

--- a/src/health_check/registry.rs
+++ b/src/health_check/registry.rs
@@ -1,8 +1,10 @@
+use crate::app::context::AppContext;
 use crate::error::RoadsterResult;
+use crate::health_check::default::default_health_checks;
 use crate::health_check::HealthCheck;
 use anyhow::anyhow;
 use std::collections::BTreeMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use tracing::info;
 
 /// Registry for [HealthCheck]s that will be run in the app.
@@ -11,46 +13,21 @@ use tracing::info;
 /// 1. As pre-boot checks to ensure the app's resource dependencies are healthy.
 /// 2. As a "core" API that can be used from multiple components, e.g. the `_health` HTTP endpoint
 ///    and the health CLI command.
-///
-/// # Internal mutability
-/// In order to make this registry available to multiple parts of the app, this is included
-/// as part of the [AppContext][crate::app::context::AppContext]. This is not strictly necessary
-/// for the Axum handlers (the registry could be provided via an [Extension][axum::Extension]),
-/// but it is (currently) required for other things, such as the CLI handlers.
-///
-/// In order to include the registry as part of the context, but also allow checks to be added
-/// to the registry after the context is created, the registry implements the
-/// [interior mutability](https://doc.rust-lang.org/reference/interior-mutability.html) pattern
-/// using a [RwLock]. As such, ___it is not recommended to register additional health checks
-/// outside of the app initialization process___ -- doing so may result in a panic.
-///
-/// Because of the internal mutability, methods that modify the internal state can accept `&self`
-/// instead of `&mut self`.
 pub struct HealthCheckRegistry {
-    health_checks: Arc<RwLock<BTreeMap<String, Arc<dyn HealthCheck>>>>,
-}
-
-impl Default for HealthCheckRegistry {
-    fn default() -> Self {
-        HealthCheckRegistry::new()
-    }
+    health_checks: BTreeMap<String, Arc<dyn HealthCheck>>,
 }
 
 impl HealthCheckRegistry {
-    pub fn new() -> Self {
+    pub(crate) fn new(context: &AppContext) -> Self {
         Self {
-            health_checks: Arc::new(RwLock::new(Default::default())),
+            health_checks: default_health_checks(context),
         }
     }
 
-    pub fn register<H>(&self, health_check: H) -> RoadsterResult<()>
+    pub fn register<H>(&mut self, health_check: H) -> RoadsterResult<()>
     where
         H: HealthCheck + 'static,
     {
-        self.register_arc(Arc::new(health_check))
-    }
-
-    pub(crate) fn register_arc(&self, health_check: Arc<dyn HealthCheck>) -> RoadsterResult<()> {
         let name = health_check.name();
 
         if !health_check.enabled() {
@@ -60,27 +37,25 @@ impl HealthCheckRegistry {
 
         info!(name=%name, "Registering health check");
 
-        let mut health_checks = self.health_checks.write().map_err(|err| {
-            anyhow!("Unable to acquire write lock on health check registry: {err}")
-        })?;
-        if health_checks.insert(name.clone(), health_check).is_some() {
+        if self
+            .health_checks
+            .insert(name.clone(), Arc::new(health_check))
+            .is_some()
+        {
             return Err(anyhow!("Health check `{}` was already registered", name).into());
         }
         Ok(())
     }
 
-    pub fn checks(&self) -> RoadsterResult<Vec<Arc<dyn HealthCheck>>> {
-        let health_checks = self
-            .health_checks
-            .read()
-            .map_err(|err| anyhow!("Unable to acquire read lock on heath check registry: {err}"))?;
-        Ok(health_checks.values().cloned().collect())
+    pub fn checks(&self) -> Vec<Arc<dyn HealthCheck>> {
+        self.health_checks.values().cloned().collect()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::app_config::AppConfig;
     use crate::health_check::MockHealthCheck;
     use rstest::rstest;
 
@@ -88,25 +63,25 @@ mod tests {
     #[case(true, 1)]
     #[case(false, 0)]
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn register_check(#[case] service_enabled: bool, #[case] expected_count: usize) {
+    fn register_check(#[case] check_enabled: bool, #[case] expected_count: usize) {
         // Arrange
+        let mut config = AppConfig::test(None).unwrap();
+        config.health_check.default_enable = false;
+        let context = AppContext::test(Some(config), None, None).unwrap();
+
         let mut check: MockHealthCheck = MockHealthCheck::default();
-        check.expect_enabled().return_const(service_enabled);
+        check.expect_enabled().return_const(check_enabled);
         check.expect_name().return_const("test".to_string());
 
         // Act
-        let subject: HealthCheckRegistry = HealthCheckRegistry::new();
+        let mut subject: HealthCheckRegistry = HealthCheckRegistry::new(&context);
         subject.register(check).unwrap();
 
         // Assert
-        assert_eq!(subject.checks().unwrap().len(), expected_count);
+        assert_eq!(subject.checks().len(), expected_count);
         assert_eq!(
-            subject
-                .checks()
-                .unwrap()
-                .iter()
-                .any(|check| check.name() == "test"),
-            service_enabled
+            subject.checks().iter().any(|check| check.name() == "test"),
+            check_enabled
         );
     }
 }

--- a/src/health_check/snapshots/roadster__health_check__default__tests__default_middleware@case_1.snap
+++ b/src/health_check/snapshots/roadster__health_check__default__tests__default_middleware@case_1.snap
@@ -2,8 +2,4 @@
 source: src/health_check/default.rs
 expression: health_checks
 ---
-[
-    'db',
-    'sidekiq-enqueue',
-    'sidekiq-fetch',
-]
+[]


### PR DESCRIPTION
Switch to using `OnceLock` to allow setting the health checks on the `AppContext` after it is created. The method to set the health checks is private to the crate, so we have control over when the checks are set on the context.

This has some impacts on public-facing APIs:
- `App::health_checks` takes a `&mut HealthCheckRegistry` instead of a non-mutable ref
- `AppContext::health_checks` returns the list of health checks. (Alternatively, we could have returned an Option)
- We also made the `HealthCheckRegistry::new` method non-public. This aligns with the `ServiceRegistry::new` visibility.

Closes https://github.com/roadster-rs/roadster/issues/257