### PR TITLE
feat: Place health check results under `resources` in response

### DIFF
--- a/src/api/core/health.rs
+++ b/src/api/core/health.rs
@@ -29,7 +29,6 @@ use tracing::{info, instrument};
 pub struct HeathCheckResponse {
     /// Total latency of checking the health of the app.
     pub latency: u128,
-    #[serde(flatten)]
     pub resources: BTreeMap<String, CheckResponse>,
 }
 


### PR DESCRIPTION
Also, log all health check failures when running health checks during app boot up.