### PR TITLE
docs: Update the `_health` HTTP API docs

### DIFF
--- a/src/api/http/health.rs
+++ b/src/api/http/health.rs
@@ -17,7 +17,6 @@ use axum::{Json, Router};
 #[cfg(feature = "open-api")]
 use schemars::JsonSchema;
 use serde_derive::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 use std::time::Duration;
 use tracing::instrument;
 
@@ -120,7 +119,10 @@ fn health_get_docs(op: TransformOperation) -> TransformOperation {
                         CheckResponse::builder()
                             .status(Status::Ok)
                             .latency(Duration::from_secs(1))
-                            .custom(BTreeMap::from([("foo", 1234), ("bar", 5000)]))
+                            .custom(std::collections::BTreeMap::from([
+                                ("foo", 1234),
+                                ("bar", 5000),
+                            ]))
                             .build(),
                     ),
                     (

--- a/src/api/http/health.rs
+++ b/src/api/http/health.rs
@@ -17,6 +17,7 @@ use axum::{Json, Router};
 #[cfg(feature = "open-api")]
 use schemars::JsonSchema;
 use serde_derive::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::time::Duration;
 use tracing::instrument;
 
@@ -119,6 +120,7 @@ fn health_get_docs(op: TransformOperation) -> TransformOperation {
                         CheckResponse::builder()
                             .status(Status::Ok)
                             .latency(Duration::from_secs(1))
+                            .custom(BTreeMap::from([("foo", 1234), ("bar", 5000)]))
                             .build(),
                     ),
                     (
@@ -134,6 +136,11 @@ fn health_get_docs(op: TransformOperation) -> TransformOperation {
                     ),
                 ]),
             })
+            .description(
+                "Health status of the app's resources. Each resource entry will
+                contain at least the `status` and `latency` fields, but can also contain arbitrary
+                data in the `custom` field.",
+            )
         })
 }
 

--- a/src/health_check/mod.rs
+++ b/src/health_check/mod.rs
@@ -29,7 +29,6 @@ pub struct CheckResponse {
     pub latency: u128,
     /// Custom health data, for example, separate latency measurements for acquiring a connection
     /// from a resource pool vs making a request with the connection.
-    #[serde(flatten)]
     #[builder(default, setter(transform = |custom: impl serde::Serialize| serialize_custom(custom) ))]
     pub custom: Option<Value>,
 }


### PR DESCRIPTION
Also, don't flatten the `custom` field of the check result.