### PR TITLE
fix: Correctly add the `ApiRouter` to the HTTP service's `ApiRouter`

### DIFF
--- a/src/service/http/builder.rs
+++ b/src/service/http/builder.rs
@@ -104,7 +104,7 @@ where
 
     #[cfg(feature = "open-api")]
     pub fn api_router(mut self, router: ApiRouter<S>) -> Self {
-        self.router = self.router.merge(router);
+        self.api_router = self.api_router.merge(router);
         self
     }
 


### PR DESCRIPTION
The `HttpServiceBuilder#api_router` method is incorrectly adding the provided `ApiRouter` to the normal axum `Router`. This means the routes defined in the provided `ApiRouter` will not show up in the generated OpenAPI schema.

Fix the method to correctly merge the provided `ApiRouter` with the `HttpServiceBuilder`'s `ApiRouter`.