### PR TITLE
chore: Remove the `update` justfile command

### DIFF
--- a/justfile
+++ b/justfile
@@ -35,10 +35,6 @@ coverage: coverage-clean
 coverage-open: coverage
     open target/llvm-cov-target/debug/coverage/index.html
 
-# Update dependencies to their latest versions.
-update:
-    cargo upgrade
-
 # Run a suite of checks. These checks are fairly comprehensive and will catch most issues. However, they are still less than what is run in CI.
 check:
     .cargo-husky/hooks/pre-push


### PR DESCRIPTION
This command updates dependencies in our Cargo.toml, which we really only want to do sparingly -- we don't want to unnecessarily bump a minor/patch version of a dep, for example.