### PR TITLE
feat: Use IDENTITY column for int primary keys instead of BIGSERIAL

### DIFF
--- a/src/migration/snapshots/roadster__migration__schema__tests__pk_bigint@pk_bigint.snap
+++ b/src/migration/snapshots/roadster__migration__schema__tests__pk_bigint@pk_bigint.snap
@@ -1,0 +1,5 @@
+---
+source: src/migration/schema.rs
+expression: table_stmt.to_string(PostgresQueryBuilder)
+---
+CREATE TABLE "foo" ( "bar" bigint NOT NULL PRIMARY KEY )

--- a/src/migration/snapshots/roadster__migration__schema__tests__pk_bigint_identity@pk_bigint_identity.snap
+++ b/src/migration/snapshots/roadster__migration__schema__tests__pk_bigint_identity@pk_bigint_identity.snap
@@ -1,0 +1,5 @@
+---
+source: src/migration/schema.rs
+expression: table_stmt.to_string(PostgresQueryBuilder)
+---
+CREATE TABLE "foo" ( "bar" bigint NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY )

--- a/src/migration/snapshots/roadster__migration__schema__tests__pk_bigint_identity_options@case_1.snap
+++ b/src/migration/snapshots/roadster__migration__schema__tests__pk_bigint_identity_options@case_1.snap
@@ -1,0 +1,5 @@
+---
+source: src/migration/schema.rs
+expression: table_stmt.to_string(PostgresQueryBuilder)
+---
+CREATE TABLE "foo" ( "bar" bigint NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1) )

--- a/src/migration/snapshots/roadster__migration__schema__tests__pk_bigint_identity_options@case_2.snap
+++ b/src/migration/snapshots/roadster__migration__schema__tests__pk_bigint_identity_options@case_2.snap
@@ -1,0 +1,5 @@
+---
+source: src/migration/schema.rs
+expression: table_stmt.to_string(PostgresQueryBuilder)
+---
+CREATE TABLE "foo" ( "bar" bigint NOT NULL PRIMARY KEY GENERATED AS IDENTITY (START WITH 1 INCREMENT BY 1) )

--- a/src/migration/snapshots/roadster__migration__schema__tests__pk_bigint_identity_options@case_3.snap
+++ b/src/migration/snapshots/roadster__migration__schema__tests__pk_bigint_identity_options@case_3.snap
@@ -1,0 +1,5 @@
+---
+source: src/migration/schema.rs
+expression: table_stmt.to_string(PostgresQueryBuilder)
+---
+CREATE TABLE "foo" ( "bar" bigint NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY (START WITH -100 INCREMENT BY 1) )

--- a/src/migration/snapshots/roadster__migration__schema__tests__pk_bigint_identity_options@case_4.snap
+++ b/src/migration/snapshots/roadster__migration__schema__tests__pk_bigint_identity_options@case_4.snap
@@ -1,0 +1,5 @@
+---
+source: src/migration/schema.rs
+expression: table_stmt.to_string(PostgresQueryBuilder)
+---
+CREATE TABLE "foo" ( "bar" bigint NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY (START WITH 0 INCREMENT BY 1) )

--- a/src/migration/user/create_and_drop_table.rs
+++ b/src/migration/user/create_and_drop_table.rs
@@ -1,5 +1,5 @@
 use crate::migration::check::str_not_empty;
-use crate::migration::schema::{pk_bigint_auto, pk_uuid, table};
+use crate::migration::schema::{pk_bigint_identity, pk_uuid, table};
 use crate::migration::user::User;
 use sea_orm_migration::{prelude::*, schema::*};
 
@@ -8,7 +8,7 @@ pub(crate) fn create_table_uuid_pk() -> TableCreateStatement {
 }
 
 pub(crate) fn create_table_int_pk() -> TableCreateStatement {
-    create_table(pk_bigint_auto(User::Id))
+    create_table(pk_bigint_identity(User::Id))
 }
 
 pub(crate) fn create_table(pk_col: ColumnDef) -> TableCreateStatement {

--- a/src/migration/user/snapshots/roadster__migration__user__create_and_drop_table__tests__create_table_int_pk.snap
+++ b/src/migration/user/snapshots/roadster__migration__user__create_and_drop_table__tests__create_table_int_pk.snap
@@ -1,5 +1,5 @@
 ---
-source: src/migration/user/create_table.rs
+source: src/migration/user/create_and_drop_table.rs
 expression: query.to_string(PostgresQueryBuilder)
 ---
-CREATE TABLE IF NOT EXISTS "user" ( "created_at" timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP, "updated_at" timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP, "id" bigserial NOT NULL PRIMARY KEY, "name" varchar NOT NULL CHECK (CHAR_LENGTH("name") > 0), "username" varchar NOT NULL UNIQUE CHECK (CHAR_LENGTH("username") > 0), "email" varchar NOT NULL UNIQUE CHECK (CHAR_LENGTH("email") > 0), "password" varchar NOT NULL )
+CREATE TABLE IF NOT EXISTS "user" ( "created_at" timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP, "updated_at" timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP, "id" bigint NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY, "name" varchar NOT NULL CHECK (CHAR_LENGTH("name") > 0), "username" varchar NOT NULL UNIQUE CHECK (CHAR_LENGTH("username") > 0), "email" varchar NOT NULL UNIQUE CHECK (CHAR_LENGTH("email") > 0), "password" varchar NOT NULL )


### PR DESCRIPTION
`BIGSERIAL` is not recommended. See: https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_serial. The recommendation is instead to use `IDENTITY` columns.

This PR updates the create `user` table migration (just the one using bigint as the primary key) to create the pk as an IDENTITY column instead of a BIGSERIAL. This PR also adds the `pk_bigint_identity` method to enable creating an IDENTITY pk in any table. The `pk_bigint_identity_options` method is added as well, which is the same except it allows configuring the sequence for the identity generation. See: https://www.postgresql.org/docs/current/sql-createsequence.html

Closes https://github.com/roadster-rs/roadster/issues/290