### PR TITLE
feat: Enable ReqResLogging middleware by default, but disable in prod

### DIFF
--- a/src/config/app_config.rs
+++ b/src/config/app_config.rs
@@ -147,8 +147,7 @@ impl AppConfig {
 
     #[allow(clippy::let_and_return)]
     fn default_config(
-        #[allow(unused_variables)]
-        environment: Environment,
+        #[allow(unused_variables)] environment: Environment,
     ) -> ConfigBuilder<DefaultState> {
         let config = Config::builder()
             .add_source(config::File::from_str(

--- a/src/config/app_config.rs
+++ b/src/config/app_config.rs
@@ -146,7 +146,10 @@ impl AppConfig {
     }
 
     #[allow(clippy::let_and_return)]
-    fn default_config(environment: Environment) -> ConfigBuilder<DefaultState> {
+    fn default_config(
+        #[allow(unused_variables)]
+        environment: Environment,
+    ) -> ConfigBuilder<DefaultState> {
         let config = Config::builder()
             .add_source(config::File::from_str(
                 include_str!("default.toml"),

--- a/src/config/app_config.rs
+++ b/src/config/app_config.rs
@@ -74,9 +74,9 @@ impl AppConfig {
         } else {
             Environment::new()?
         };
-        let environment_str: &str = environment.into();
+        let environment_str: &str = environment.clone().into();
 
-        let config = Self::default_config()
+        let config = Self::default_config(environment)
             // Todo: allow other file formats?
             // Todo: allow splitting config into multiple files?
             .add_source(config::File::with_name("config/default.toml"))
@@ -99,7 +99,7 @@ impl AppConfig {
     #[cfg(test)]
     #[cfg_attr(coverage_nightly, coverage(off))]
     pub(crate) fn test(config_str: Option<&str>) -> RoadsterResult<Self> {
-        let config = Self::default_config()
+        let config = Self::default_config(Environment::Test)
             .add_source(config::File::from_str(
                 config_str.unwrap_or(
                     r#"
@@ -146,7 +146,7 @@ impl AppConfig {
     }
 
     #[allow(clippy::let_and_return)]
-    fn default_config() -> ConfigBuilder<DefaultState> {
+    fn default_config(environment: Environment) -> ConfigBuilder<DefaultState> {
         let config = Config::builder()
             .add_source(config::File::from_str(
                 include_str!("default.toml"),
@@ -155,7 +155,13 @@ impl AppConfig {
             .add_source(crate::config::tracing::default_config());
 
         #[cfg(feature = "http")]
-        let config = config.add_source(crate::config::service::http::default_config());
+        let config = {
+            let config = config.add_source(crate::config::service::http::default_config());
+            let config = crate::config::service::http::default_config_per_env(environment)
+                .into_iter()
+                .fold(config, |config, source| config.add_source(source));
+            config
+        };
 
         #[cfg(feature = "grpc")]
         let config = config.add_source(crate::config::service::grpc::default_config());

--- a/src/config/service/http/config/default.toml
+++ b/src/config/service/http/config/default.toml
@@ -42,7 +42,6 @@ limit = "5 MB"
 priority = -9950
 
 [service.http.middleware.request-response-logging]
-enable = false
 priority = 0
 
 # Initializers

--- a/src/config/service/http/config/production.toml
+++ b/src/config/service/http/config/production.toml
@@ -1,0 +1,2 @@
+[service.http.middleware.request-response-logging]
+enable = false

--- a/src/config/service/http/mod.rs
+++ b/src/config/service/http/mod.rs
@@ -1,3 +1,4 @@
+use crate::config::environment::Environment;
 use crate::config::service::common::address::Address;
 use crate::config::service::http::initializer::Initializer;
 use crate::config::service::http::middleware::Middleware;
@@ -11,7 +12,17 @@ pub mod initializer;
 pub mod middleware;
 
 pub fn default_config() -> config::File<FileSourceString, FileFormat> {
-    config::File::from_str(include_str!("default.toml"), FileFormat::Toml)
+    config::File::from_str(include_str!("config/default.toml"), FileFormat::Toml)
+}
+
+pub(crate) fn default_config_per_env(
+    environment: Environment,
+) -> Option<config::File<FileSourceString, FileFormat>> {
+    let config = match environment {
+        Environment::Production => Some(include_str!("config/production.toml")),
+        _ => None,
+    };
+    config.map(|c| config::File::from_str(c, FileFormat::Toml))
 }
 
 #[derive(Debug, Clone, Validate, Serialize, Deserialize)]

--- a/src/config/snapshots/roadster__config__app_config__tests__test.snap
+++ b/src/config/snapshots/roadster__config__app_config__tests__test.snap
@@ -82,7 +82,6 @@ preset = 'restrictive'
 max-age = 3600000
 
 [service.http.middleware.request-response-logging]
-enable = false
 priority = 0
 
 [service.http.initializer]

--- a/src/service/http/middleware/snapshots/roadster__service__http__middleware__default__tests__default_middleware@case_2.snap
+++ b/src/service/http/middleware/snapshots/roadster__service__http__middleware__default__tests__default_middleware@case_2.snap
@@ -8,6 +8,7 @@ expression: middleware
     'propagate-request-id',
     'request-body-size-limit',
     'request-decompression',
+    'request-response-logging',
     'sensitive-request-headers',
     'sensitive-response-headers',
     'set-request-id',


### PR DESCRIPTION
Update the default app config to allow different defaults per environment, so ReqResLogging middleware can be enabled by default, but disabled in prod.