### PR TITLE
feat: Allow configuring the max len for the `ReqResLoggingMiddleware`

### DIFF
--- a/src/config/service/http/config/default.toml
+++ b/src/config/service/http/config/default.toml
@@ -43,6 +43,7 @@ priority = -9950
 
 [service.http.middleware.request-response-logging]
 priority = 0
+max-len = 1000
 
 # Initializers
 [service.http.initializer]

--- a/src/config/service/http/config/production.toml
+++ b/src/config/service/http/config/production.toml
@@ -1,2 +1,3 @@
 [service.http.middleware.request-response-logging]
 enable = false
+max-len = 0

--- a/src/config/service/http/middleware.rs
+++ b/src/config/service/http/middleware.rs
@@ -11,7 +11,7 @@ use crate::service::http::middleware::sensitive_headers::{
 };
 use crate::service::http::middleware::size_limit::SizeLimitConfig;
 use crate::service::http::middleware::timeout::TimeoutConfig;
-use crate::service::http::middleware::tracing::req_res_logging::ReqResLoggingConfig;
+use crate::service::http::middleware::tracing::req_res_logging::RequestResponseLoggingConfig;
 use crate::service::http::middleware::tracing::TracingConfig;
 use crate::util::serde::default_true;
 use axum::extract::FromRef;
@@ -51,7 +51,7 @@ pub struct Middleware {
 
     pub cors: MiddlewareConfig<CorsConfig>,
 
-    pub request_response_logging: MiddlewareConfig<ReqResLoggingConfig>,
+    pub request_response_logging: MiddlewareConfig<RequestResponseLoggingConfig>,
 
     /// Allows providing configs for custom middleware. Any configs that aren't pre-defined above
     /// will be collected here.

--- a/src/config/snapshots/roadster__config__app_config__tests__test.snap
+++ b/src/config/snapshots/roadster__config__app_config__tests__test.snap
@@ -83,6 +83,7 @@ max-age = 3600000
 
 [service.http.middleware.request-response-logging]
 priority = 0
+max-len = 1000
 
 [service.http.initializer]
 default-enable = true

--- a/src/service/http/middleware/default.rs
+++ b/src/service/http/middleware/default.rs
@@ -10,7 +10,7 @@ use crate::service::http::middleware::sensitive_headers::{
 };
 use crate::service::http::middleware::size_limit::RequestBodyLimitMiddleware;
 use crate::service::http::middleware::timeout::TimeoutMiddleware;
-use crate::service::http::middleware::tracing::req_res_logging::RequestLoggingMiddleware;
+use crate::service::http::middleware::tracing::req_res_logging::RequestResponseLoggingMiddleware;
 use crate::service::http::middleware::tracing::TracingMiddleware;
 use crate::service::http::middleware::Middleware;
 use axum::extract::FromRef;
@@ -32,7 +32,7 @@ where
         Box::new(TimeoutMiddleware),
         Box::new(RequestBodyLimitMiddleware),
         Box::new(CorsMiddleware),
-        Box::new(RequestLoggingMiddleware),
+        Box::new(RequestResponseLoggingMiddleware),
     ];
     middleware
         .into_iter()


### PR DESCRIPTION
Some payloads can be massive, so it's a good idea to add a limit to the size of log that will be emitted by the
`RequestResponseLoggingMiddleware`. To remove the limit, the `max-len` config can be set to a negative number.

Closes https://github.com/roadster-rs/roadster/issues/306