### PR TITLE
feat: Extract JWT from cookie

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tracing-opentelemetry = { version = "0.25.0", features = ["metrics"], optional =
 # `axum` is not optional because we use the `FromRef` trait pretty extensively, even in parts of
 # the code that wouldn't otherwise need `axum`.
 axum = { workspace = true, features = ["macros"] }
-axum-extra = { version = "0.9.0", features = ["typed-header"], optional = true }
+axum-extra = { version = "0.9.0", features = ["typed-header", "cookie"], optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.5.0", features = ["trace", "timeout", "request-id", "util", "normalize-path", "sensitive-headers", "catch-panic", "compression-full", "decompression-full", "limit", "cors"], optional = true }
 aide = { workspace = true, features = ["axum", "redoc", "scalar", "macros"], optional = true }

--- a/src/config/auth/mod.rs
+++ b/src/config/auth/mod.rs
@@ -14,7 +14,13 @@ pub struct Auth {
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct Jwt {
+    /// Name of the cookie used to pass the JWT access token. If not set, will use
+    /// [`axum::http::header::AUTHORIZATION`] as the cookie name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cookie_name: Option<String>,
+
     pub secret: String,
+
     #[serde(default)]
     #[validate(nested)]
     pub claims: JwtClaims,

--- a/src/error/auth.rs
+++ b/src/error/auth.rs
@@ -11,6 +11,10 @@ pub enum AuthError {
     #[error(transparent)]
     Jwt(#[from] jsonwebtoken::errors::Error),
 
+    #[cfg(feature = "http")]
+    #[error(transparent)]
+    Bearer(#[from] axum_extra::headers::authorization::InvalidBearerToken),
+
     #[error(transparent)]
     Other(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
@@ -18,6 +22,13 @@ pub enum AuthError {
 #[cfg(feature = "jwt")]
 impl From<jsonwebtoken::errors::Error> for Error {
     fn from(value: jsonwebtoken::errors::Error) -> Self {
+        Self::Auth(AuthError::from(value))
+    }
+}
+
+#[cfg(feature = "http")]
+impl From<axum_extra::headers::authorization::InvalidBearerToken> for Error {
+    fn from(value: axum_extra::headers::authorization::InvalidBearerToken) -> Self {
         Self::Auth(AuthError::from(value))
     }
 }

--- a/src/error/axum.rs
+++ b/src/error/axum.rs
@@ -4,6 +4,9 @@ use crate::error::Error;
 #[non_exhaustive]
 pub enum AxumError {
     #[error(transparent)]
+    Error(#[from] axum::http::Error),
+
+    #[error(transparent)]
     InvalidHeaderName(#[from] axum::http::header::InvalidHeaderName),
 
     #[error(transparent)]
@@ -18,6 +21,12 @@ pub enum AxumError {
 
     #[error(transparent)]
     Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl From<axum::http::Error> for Error {
+    fn from(value: axum::http::Error) -> Self {
+        Self::Axum(AxumError::from(value))
+    }
 }
 
 impl From<axum::http::header::InvalidHeaderName> for Error {

--- a/src/error/axum.rs
+++ b/src/error/axum.rs
@@ -15,6 +15,9 @@ pub enum AxumError {
     #[error(transparent)]
     InvalidMethod(#[from] axum::http::method::InvalidMethod),
 
+    #[error(transparent)]
+    ToStrError(#[from] axum::http::header::ToStrError),
+
     #[cfg(feature = "jwt")]
     #[error(transparent)]
     TypedHeaderRejection(#[from] axum_extra::typed_header::TypedHeaderRejection),
@@ -43,6 +46,12 @@ impl From<axum::http::header::InvalidHeaderValue> for Error {
 
 impl From<axum::http::method::InvalidMethod> for Error {
     fn from(value: axum::http::method::InvalidMethod) -> Self {
+        Self::Axum(AxumError::from(value))
+    }
+}
+
+impl From<axum::http::header::ToStrError> for Error {
+    fn from(value: axum::http::header::ToStrError) -> Self {
         Self::Axum(AxumError::from(value))
     }
 }

--- a/src/middleware/http/auth/jwt/ietf.rs
+++ b/src/middleware/http/auth/jwt/ietf.rs
@@ -6,25 +6,29 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::serde_as;
 use std::collections::BTreeMap;
+use typed_builder::TypedBuilder;
 
 /// JWT Claims. Provides fields for the default/recommended registered claim names. Additional
 /// claim names are collected in the `custom` map.
 /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4>
 #[serde_as]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, TypedBuilder)]
 #[non_exhaustive]
 pub struct Claims {
     /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.1>
     #[serde(rename = "iss")]
+    #[builder(default, setter(strip_option))]
     pub issuer: Option<UriOrString>,
 
     /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.2>
     #[serde(rename = "sub")]
+    #[builder(default, setter(strip_option))]
     pub subject: Option<Subject>,
 
     /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.3>
     #[serde(rename = "aud", default, skip_serializing_if = "Vec::is_empty")]
     #[serde_as(deserialize_as = "serde_with::OneOrMany<_>")]
+    #[builder(default)]
     pub audience: Vec<UriOrString>,
 
     /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.4>
@@ -35,18 +39,22 @@ pub struct Claims {
     /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.5>
     #[serde(rename = "nbf")]
     #[serde_as(as = "Option<serde_with::TimestampSeconds>")]
+    #[builder(default, setter(strip_option))]
     pub not_before: Option<DateTime<Utc>>,
 
     /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.6>
     #[serde(rename = "iat")]
     #[serde_as(as = "Option<serde_with::TimestampSeconds>")]
+    #[builder(default, setter(strip_option))]
     pub issued_at: Option<DateTime<Utc>>,
 
     /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.7>
     #[serde(rename = "jti")]
+    #[builder(default, setter(strip_option))]
     pub jwt_id: Option<String>,
 
     #[serde(flatten)]
+    #[builder(default)]
     pub custom: BTreeMap<String, Value>,
 }
 

--- a/src/middleware/http/auth/jwt/mod.rs
+++ b/src/middleware/http/auth/jwt/mod.rs
@@ -4,6 +4,7 @@ pub mod ietf;
 pub mod openid;
 
 use crate::app::context::AppContext;
+use crate::error::api::http::HttpError;
 use crate::error::{Error, RoadsterResult};
 #[cfg(feature = "jwt-ietf")]
 use crate::middleware::http::auth::jwt::ietf::Claims;
@@ -14,8 +15,10 @@ use crate::util::serde::{deserialize_from_str, serialize_to_str};
 use aide::OperationInput;
 use async_trait::async_trait;
 use axum::extract::{FromRef, FromRequestParts};
+use axum::http::header::AUTHORIZATION;
 use axum::http::request::Parts;
 use axum::RequestPartsExt;
+use axum_extra::extract::CookieJar;
 use axum_extra::headers::authorization::Bearer;
 use axum_extra::headers::Authorization;
 use axum_extra::TypedHeader;
@@ -58,10 +61,38 @@ where
     type Rejection = Error;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let auth_header = parts.extract::<BearerAuthHeader>().await?;
         let context = AppContext::from_ref(state);
+
+        let token = parts
+            .extract::<BearerAuthHeader>()
+            .await
+            .ok()
+            .map(|auth_header| auth_header.0.token().to_string());
+        let token = if token.is_some() {
+            token
+        } else {
+            let cookie_name = context
+                .config()
+                .auth
+                .jwt
+                .cookie_name
+                .clone()
+                .unwrap_or_else(|| AUTHORIZATION.to_string());
+            let cookies = parts.extract::<CookieJar>().await.ok();
+            cookies
+                .as_ref()
+                .and_then(|cookies| cookies.get(&cookie_name))
+                .map(|cookie| cookie.value().to_string())
+        };
+
+        let token = if let Some(token) = token {
+            token
+        } else {
+            return Err(HttpError::unauthorized().into());
+        };
+
         let token: TokenData<C> = decode_auth_token(
-            auth_header.0.token(),
+            &token,
             &context.config().auth.jwt.secret,
             &context.config().auth.jwt.claims.audience,
             &context.config().auth.jwt.claims.required_claims,

--- a/src/middleware/http/auth/jwt/openid.rs
+++ b/src/middleware/http/auth/jwt/openid.rs
@@ -5,6 +5,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::serde_as;
 use std::collections::BTreeMap;
+use typed_builder::TypedBuilder;
 use url::Url;
 
 use crate::util::serde::{deserialize_from_str, serialize_to_str, UriOrString};
@@ -13,7 +14,7 @@ use crate::util::serde::{deserialize_from_str, serialize_to_str, UriOrString};
 /// claim names are collected in the `custom` map.
 /// See: <https://openid.net/specs/openid-connect-core-1_0.html#IDToken>
 #[serde_as]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, TypedBuilder)]
 #[non_exhaustive]
 pub struct Claims {
     #[serde(rename = "iss")]
@@ -24,6 +25,7 @@ pub struct Claims {
 
     #[serde(rename = "aud", default, skip_serializing_if = "Vec::is_empty")]
     #[serde_as(deserialize_as = "serde_with::OneOrMany<_>")]
+    #[builder(default)]
     pub audience: Vec<UriOrString>,
 
     #[serde(rename = "exp", with = "ts_seconds")]
@@ -33,23 +35,29 @@ pub struct Claims {
     pub issued_at: DateTime<Utc>,
 
     #[serde_as(as = "Option<serde_with::TimestampSeconds>")]
+    #[builder(setter(strip_option))]
     pub auth_time: Option<DateTime<Utc>>,
 
+    #[builder(setter(strip_option))]
     pub nonce: Option<String>,
 
     #[serde(rename = "acr")]
+    #[builder(setter(strip_option))]
     pub auth_cxt_class_reference: Option<Acr>,
 
     #[serde(rename = "amr", default, skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
     pub auth_methods_references: Vec<String>,
 
     /// Note per the OpenID docs: "\[...\] in practice, the azp Claim only occurs when extensions
     /// beyond the scope of this specification are used; therefore, implementations not using such
     /// extensions are encouraged to not use azp and to ignore it when it does occur."
     #[serde(rename = "azp")]
+    #[builder(setter(strip_option))]
     pub authorized_party: Option<UriOrString>,
 
     #[serde(flatten)]
+    #[builder(default)]
     pub custom: BTreeMap<String, Value>,
 }
 


### PR DESCRIPTION
If the `BearerAuthHeader` header is missing, attempt to get the JWT from the `AUTHORIZATION` header. If the JWT is not available from either source, reject the response with an "unauthorized" response.