### PR TITLE
fix: Do not simply use bearer token from cookie for auth

### DIFF
--- a/src/config/auth/mod.rs
+++ b/src/config/auth/mod.rs
@@ -18,6 +18,10 @@ pub struct Jwt {
     /// Name of the cookie used to pass the JWT access token. If not set, will use
     /// [`AUTHORIZATION`] as the cookie name.
     #[serde(default = "Jwt::default_cookie_name")]
+    #[deprecated(
+        since = "0.5.19",
+        note = "Using jwt from cookie is/may be a CSRF vulnerability. This functionality is removed for now and this config field is not used."
+    )]
     pub cookie_name: String,
 
     pub secret: String,

--- a/src/middleware/http/auth/jwt/snapshots/roadster__middleware__http__auth__jwt__tests__bearer_token_from_cookies@invalid_token.snap
+++ b/src/middleware/http/auth/jwt/snapshots/roadster__middleware__http__auth__jwt__tests__bearer_token_from_cookies@invalid_token.snap
@@ -1,5 +1,0 @@
----
-source: src/middleware/http/auth/jwt/mod.rs
-expression: token
----
-None

--- a/src/middleware/http/auth/jwt/snapshots/roadster__middleware__http__auth__jwt__tests__bearer_token_from_cookies@valid_token.snap
+++ b/src/middleware/http/auth/jwt/snapshots/roadster__middleware__http__auth__jwt__tests__bearer_token_from_cookies@valid_token.snap
@@ -1,7 +1,0 @@
----
-source: src/middleware/http/auth/jwt/mod.rs
-expression: token
----
-Some(
-    "foo",
-)


### PR DESCRIPTION
This approach is/may be  vulnerable to a CSRF attack. More care/research is needed before taking this approach. For now, it's safer to simply use the authorization header.