### PR TITLE
feat: Allow jwt from cookie, but only if it's explicitly requested

### DIFF
--- a/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_2.snap
+++ b/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_2.snap
@@ -3,7 +3,6 @@ source: src/config/auth/mod.rs
 expression: auth
 ---
 [jwt]
-cookie-name = 'authorization'
 secret = 'foo'
 
 [jwt.claims]

--- a/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_3.snap
+++ b/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_3.snap
@@ -3,7 +3,6 @@ source: src/config/auth/mod.rs
 expression: auth
 ---
 [jwt]
-cookie-name = 'authorization'
 secret = 'foo'
 
 [jwt.claims]

--- a/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_4.snap
+++ b/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_4.snap
@@ -3,7 +3,6 @@ source: src/config/auth/mod.rs
 expression: auth
 ---
 [jwt]
-cookie-name = 'authorization'
 secret = 'foo'
 
 [jwt.claims]

--- a/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_5.snap
+++ b/src/config/auth/snapshots/roadster__config__auth__tests__auth@case_5.snap
@@ -3,6 +3,7 @@ source: src/config/auth/mod.rs
 expression: auth
 ---
 [jwt]
+cookie-name = 'authorization'
 secret = 'foo'
 
 [jwt.claims]

--- a/src/config/snapshots/roadster__config__app_config__tests__test.snap
+++ b/src/config/snapshots/roadster__config__app_config__tests__test.snap
@@ -133,7 +133,6 @@ timeout = true
 max-duration = 60
 disable-argument-coercion = false
 [auth.jwt]
-cookie-name = 'authorization'
 secret = 'secret-test'
 
 [auth.jwt.claims]

--- a/src/middleware/http/auth/jwt/snapshots/roadster__middleware__http__auth__jwt__tests__bearer_token_from_cookies@invalid_token.snap
+++ b/src/middleware/http/auth/jwt/snapshots/roadster__middleware__http__auth__jwt__tests__bearer_token_from_cookies@invalid_token.snap
@@ -1,0 +1,5 @@
+---
+source: src/middleware/http/auth/jwt/mod.rs
+expression: token
+---
+None

--- a/src/middleware/http/auth/jwt/snapshots/roadster__middleware__http__auth__jwt__tests__bearer_token_from_cookies@valid_token.snap
+++ b/src/middleware/http/auth/jwt/snapshots/roadster__middleware__http__auth__jwt__tests__bearer_token_from_cookies@valid_token.snap
@@ -1,0 +1,7 @@
+---
+source: src/middleware/http/auth/jwt/mod.rs
+expression: token
+---
+Some(
+    "foo",
+)


### PR DESCRIPTION
Getting the JWT from the cookie seems to be acceptable, and is useful for GET requests (e.g., initial page load when using SSR). However, for POST requests it should be accompanied with some CSRF protection mechanism. At the moment, the CSRF validation will need to be performed by the consuming application.