### PR TITLE
feat: Remove cookie extraction for `Jwt`, but allow it in `JwtCsrf`

### DIFF
--- a/examples/leptos-ssr/Cargo.toml
+++ b/examples/leptos-ssr/Cargo.toml
@@ -42,15 +42,15 @@ leptos-example-migration = { path = "migration", optional = true }
 serde = { workspace = true, features = ["derive"] }
 
 # Leptos
-leptos = "0.6.3"
+leptos = "0.6.14"
 console_error_panic_hook = "0.1"
-leptos_axum = { version = "0.6.3", optional = true }
-leptos_meta = { version = "0.6.3" }
-leptos_router = { version = "0.6.3" }
-leptos_config = { version = "0.6.3" }
+leptos_axum = { version = "0.6.14", optional = true }
+leptos_meta = { version = "0.6.14" }
+leptos_router = { version = "0.6.14" }
+leptos_config = { version = "0.6.14" }
 tower = "0.4.13"
 tower-http = { version = "0.5", features = ["fs"], optional = true }
-wasm-bindgen = "=0.2.92"
+wasm-bindgen = "=0.2.93"
 
 # Defines a size-optimized profile for the WASM bundle in release mode
 # Commented out here because profiles are ignored for packages that aren't the workspace root


### PR DESCRIPTION
Add a new axum extractor called `JwtCsrf` that allows extracting the JWT from a cookie (if the `auth.jwt.cookie-name` config is set). This extractor provides some metadata about whether it's safe to use the JWT or if a CSRF protection mechanism needs to be applied first.

With this, we also remove cookie extraction from the normal `Jwt`, so it can safely be used without any CSRF protection mechanisms.