### PR TITLE
feat!: App methods take `self`

### DIFF
--- a/examples/full/src/app.rs
+++ b/examples/full/src/app.rs
@@ -30,17 +30,18 @@ impl RoadsterApp<AppState> for App {
     type Cli = AppCli;
     type M = Migrator;
 
-    fn metadata(_config: &AppConfig) -> RoadsterResult<AppMetadata> {
+    fn metadata(&self, _config: &AppConfig) -> RoadsterResult<AppMetadata> {
         Ok(AppMetadata::builder()
             .version(env!("VERGEN_GIT_SHA").to_string())
             .build())
     }
 
-    async fn provide_state(app_context: AppContext) -> RoadsterResult<AppState> {
+    async fn provide_state(&self, app_context: AppContext) -> RoadsterResult<AppState> {
         Ok(AppState { app_context })
     }
 
     async fn services(
+        &self,
         registry: &mut ServiceRegistry<Self, AppState>,
         state: &AppState,
     ) -> RoadsterResult<()> {

--- a/examples/leptos-ssr/src/server/mod.rs
+++ b/examples/leptos-ssr/src/server/mod.rs
@@ -28,13 +28,13 @@ impl RoadsterApp<AppState> for Server {
     type Cli = crate::cli::AppCli;
     type M = Migrator;
 
-    fn metadata(_config: &AppConfig) -> RoadsterResult<AppMetadata> {
+    fn metadata(&self, _config: &AppConfig) -> RoadsterResult<AppMetadata> {
         Ok(AppMetadata::builder()
             .version(env!("VERGEN_GIT_SHA").to_string())
             .build())
     }
 
-    async fn provide_state(app_context: AppContext) -> RoadsterResult<AppState> {
+    async fn provide_state(&self, app_context: AppContext) -> RoadsterResult<AppState> {
         let leptos_config = get_configuration(None).await.map_err(|e| anyhow!(e))?;
         let leptos_options = leptos_config.leptos_options.clone();
         let state = AppState {
@@ -46,6 +46,7 @@ impl RoadsterApp<AppState> for Server {
     }
 
     async fn services(
+        &self,
         registry: &mut ServiceRegistry<Self, AppState>,
         state: &AppState,
     ) -> RoadsterResult<()> {

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -23,9 +23,11 @@ pub struct AppContext {
 impl AppContext {
     // This method isn't used when running tests; only the mocked version is used.
     #[cfg_attr(test, allow(dead_code))]
-    // The `A` type parameter isn't used in some feature configurations
-    #[allow(clippy::extra_unused_type_parameters)]
-    pub(crate) async fn new<A, S>(config: AppConfig, metadata: AppMetadata) -> RoadsterResult<Self>
+    pub(crate) async fn new<A, S>(
+        #[allow(unused_variables)] app: &A,
+        config: AppConfig,
+        metadata: AppMetadata,
+    ) -> RoadsterResult<Self>
     where
         S: Clone + Send + Sync + 'static,
         AppContext: FromRef<S>,
@@ -39,7 +41,7 @@ impl AppContext {
         #[cfg(not(test))]
         let context = {
             #[cfg(feature = "db-sql")]
-            let db = sea_orm::Database::connect(A::db_connection_options(&config)?).await?;
+            let db = sea_orm::Database::connect(app.db_connection_options(&config)?).await?;
 
             #[cfg(feature = "sidekiq")]
             let (redis_enqueue, redis_fetch) = {

--- a/src/service/function/service.rs
+++ b/src/service/function/service.rs
@@ -68,10 +68,11 @@ impl RoadsterApp<AppContext> for App {
 #     type Cli = AppCli;
 #     type M = Migrator;
 #
-#     async fn provide_state(_context: AppContext) -> RoadsterResult<AppContext> {
+#     async fn provide_state(&self, _context: AppContext) -> RoadsterResult<AppContext> {
 #         todo!()
 #     }
     async fn services(
+        &self,
         registry: &mut ServiceRegistry<Self, AppContext>,
         context: &AppContext,
     ) -> RoadsterResult<()> {


### PR DESCRIPTION
It may be useful for consumers to be able to put state on their App implementation that they can use in the app trait. For example, I wanted this when I was working on generating an OpenAPI client from the app's Aide OpenAPI schema.

Also, this would be needed in order to support a builder-style approach to building the app. This would allow us to provide a default app impl configured with a builder-style api. We may still allow consumers to directly use the trait impl if they want.

Closes https://github.com/roadster-rs/roadster/issues/272