### PR TITLE
chore: Update leptos example to use site-addr and env from roadster config

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -13,5 +13,8 @@ min-connections = 0
 max-connections = 10
 
 [service.http]
+# Listen on any ipv4 or ipv6 addr, useful to allow connections from LAN for local dev
+# host = "[::]"
+# Listen only on localhost
 host = "127.0.0.1"
 port = 3000

--- a/examples/full/config/default.toml
+++ b/examples/full/config/default.toml
@@ -13,6 +13,9 @@ min-connections = 0
 max-connections = 10
 
 [service.http]
+# Listen on any ipv4 or ipv6 addr, useful to allow connections from LAN for local dev
+# host = "[::]"
+# Listen only on localhost
 host = "127.0.0.1"
 port = 3000
 

--- a/examples/leptos-ssr/Cargo.toml
+++ b/examples/leptos-ssr/Cargo.toml
@@ -84,9 +84,6 @@ style-file = "style/main.scss"
 # Optional. Env: LEPTOS_ASSETS_DIR.
 assets-dir = "public"
 
-# The IP and port (ex: 127.0.0.1:3000) where the server serves the content. Use it in your server setup.
-site-addr = "127.0.0.1:3000"
-
 # The port to use for automatic reload monitoring
 reload-port = 3001
 
@@ -98,9 +95,6 @@ end2end-dir = "end2end"
 
 #  The browserlist query used for optimizing the CSS.
 browserquery = "defaults"
-
-# The environment Leptos will run in, usually either "DEV" or "PROD"
-env = "DEV"
 
 # The features to use when compiling the bin target
 #

--- a/examples/leptos-ssr/src/server/mod.rs
+++ b/examples/leptos-ssr/src/server/mod.rs
@@ -6,11 +6,13 @@ use async_trait::async_trait;
 use axum::Router;
 use leptos::get_configuration;
 use leptos_axum::{generate_route_list, LeptosRoutes};
+use leptos_config::{ConfFile, Env};
 use migration::Migrator;
 use roadster::app::context::AppContext;
 use roadster::app::metadata::AppMetadata;
 use roadster::app::App as RoadsterApp;
 use roadster::config::app_config::AppConfig;
+use roadster::config::environment::Environment;
 use roadster::error::RoadsterResult;
 use roadster::service::http::service::HttpService;
 use roadster::service::registry::ServiceRegistry;
@@ -35,7 +37,7 @@ impl RoadsterApp<AppState> for Server {
     }
 
     async fn provide_state(&self, app_context: AppContext) -> RoadsterResult<AppState> {
-        let leptos_config = get_configuration(None).await.map_err(|e| anyhow!(e))?;
+        let leptos_config = leptos_config(&app_context).await?;
         let leptos_options = leptos_config.leptos_options.clone();
         let state = AppState {
             app_context,
@@ -63,17 +65,32 @@ impl RoadsterApp<AppState> for Server {
                 .socket_addr()?,
             "Leptos address does not match the Roadster http address."
         );
-        let routes = generate_route_list(App);
+
         registry
             .register_builder(
-                HttpService::builder(Some(BASE), &state.clone()).router(
-                    Router::<AppState>::new()
-                        .leptos_routes(&state, routes, App)
-                        .fallback(file_and_error_handler),
-                ),
+                HttpService::builder(Some(BASE), &state).router(leptos_routes(&state)),
             )
             .await?;
 
         Ok(())
     }
+}
+
+async fn leptos_config(context: &AppContext) -> anyhow::Result<ConfFile> {
+    let mut config = get_configuration(Some("./Cargo.toml"))
+        .await
+        .map_err(|e| anyhow!(e))?;
+    config.leptos_options.site_addr = context.config().service.http.custom.address.socket_addr()?;
+    config.leptos_options.env = match context.config().environment {
+        Environment::Production => Env::PROD,
+        _ => Env::DEV,
+    };
+    Ok(config)
+}
+
+pub fn leptos_routes(state: &AppState) -> Router<AppState> {
+    let state = state.clone();
+    Router::<AppState>::new()
+        .leptos_routes(&state, generate_route_list(App), App)
+        .fallback(file_and_error_handler)
 }


### PR DESCRIPTION
Also provide commented-out example of listening on all ipv4 and ipv6 in order to allow connections from LAN for development