### PR TITLE
feat: Allow splitting config files into many files in env directories

### DIFF
--- a/examples/full/config/default.toml
+++ b/examples/full/config/default.toml
@@ -4,14 +4,6 @@ name = "Minimal Example"
 [tracing]
 level = "debug"
 
-[database]
-auto-migrate = true
-connect-timeout = 5000
-acquire-timeout = 5000
-idle-timeout = 60
-min-connections = 0
-max-connections = 10
-
 [service.http]
 # Listen on any ipv4 or ipv6 addr, useful to allow connections from LAN for local dev
 # host = "[::]"
@@ -22,6 +14,3 @@ port = 3000
 [service.grpc]
 host = "127.0.0.1"
 port = 3001
-
-[service.sidekiq]
-queues = ["default"]

--- a/examples/full/config/default/database.toml
+++ b/examples/full/config/default/database.toml
@@ -1,0 +1,7 @@
+[database]
+auto-migrate = true
+connect-timeout = 5000
+acquire-timeout = 5000
+idle-timeout = 60
+min-connections = 0
+max-connections = 10

--- a/examples/full/config/default/sidekiq.toml
+++ b/examples/full/config/default/sidekiq.toml
@@ -1,0 +1,2 @@
+[service.sidekiq]
+queues = ["default"]

--- a/examples/full/config/development.toml
+++ b/examples/full/config/development.toml
@@ -6,9 +6,3 @@ secret = "secret-dev"
 
 [database]
 uri = "postgres://roadster:roadster@localhost:5432/full_dev"
-
-[service.sidekiq]
-num-workers = 2
-
-[service.sidekiq.redis]
-uri = "redis://localhost:6379"

--- a/examples/full/config/development/sidekiq.toml
+++ b/examples/full/config/development/sidekiq.toml
@@ -1,0 +1,5 @@
+[service.sidekiq]
+num-workers = 2
+
+[service.sidekiq.redis]
+uri = "redis://localhost:6379"


### PR DESCRIPTION
As an application grows, it will need to define many different config fields. This can easily become unweildy to maintain in a single file.

This PR adds support for env-specific config directories. All config files (`.toml` only currently) in the env's directory will be merged into the final config at runtime. The directory is traversed recursively, so nested directory structures are supported.