### PR TITLE
feat: Make the `User` sea-orm migration enum public

### DIFF
--- a/src/migration/schema.rs
+++ b/src/migration/schema.rs
@@ -8,29 +8,7 @@
 use sea_orm_migration::{prelude::*, schema::*};
 use typed_builder::TypedBuilder;
 
-/// Timestamp related fields.
-#[derive(DeriveIden)]
-#[non_exhaustive]
-pub enum Timestamps {
-    /// When the row was created. When used with the [timestamps] method, will default to
-    /// the current timestamp (with timezone).
-    CreatedAt,
-    /// When the row was updated. When used with the [timestamps] method, will be initially set to
-    /// the current timestamp (with timezone).
-    ///
-    /// To automatically update the value for a row whenever the row is updated, include the
-    /// [crate::migration::timestamp::m20240723_201404_add_update_timestamp_function::Migration]
-    /// in your [MigratorTrait] implementation, along with a [MigrationTrait] for your table
-    /// that add a trigger to update the column. Helper methods are provided for this in
-    /// the [crate::migration::timestamp] module. Specifically, see:
-    /// - [crate::migration::timestamp::exec_create_update_timestamp_trigger]
-    /// - [crate::migration::timestamp::exec_drop_update_timestamp_trigger]
-    ///
-    /// Note that the auto-updates mentioned above are currently only supported on Postgres. If
-    /// an app is using a different DB, it will need to manually update the timestamp when updating
-    /// a row.
-    UpdatedAt,
-}
+pub use crate::migration::timestamp::Timestamps;
 
 /// Create a table if it does not exist yet and add some default columns
 /// (e.g., create/update timestamps).

--- a/src/migration/schema.rs
+++ b/src/migration/schema.rs
@@ -8,6 +8,10 @@
 use sea_orm_migration::{prelude::*, schema::*};
 use typed_builder::TypedBuilder;
 
+#[deprecated(
+    since = "0.6.0",
+    note = "Moved to migration::timestamps, import from there instead."
+)]
 pub use crate::migration::timestamp::Timestamps;
 
 /// Create a table if it does not exist yet and add some default columns

--- a/src/migration/timestamp/m20240723_201404_add_update_timestamp_function.rs
+++ b/src/migration/timestamp/m20240723_201404_add_update_timestamp_function.rs
@@ -3,7 +3,7 @@
 //!
 //! Note: Currently only supports Postgres. If another DB is used, will do nothing.
 
-use crate::migration::schema::Timestamps;
+use crate::migration::timestamp::Timestamps;
 use crate::migration::timestamp::{
     exec_create_update_timestamp_function, exec_drop_update_timestamp_function,
 };

--- a/src/migration/timestamp/mod.rs
+++ b/src/migration/timestamp/mod.rs
@@ -5,12 +5,36 @@ use sea_orm_migration::prelude::*;
 
 pub mod m20240723_201404_add_update_timestamp_function;
 
+/// Timestamp related fields.
+#[derive(DeriveIden)]
+#[non_exhaustive]
+pub enum Timestamps {
+    /// When the row was created. When used with the [crate::migration::schema::timestamps] method, will default to
+    /// the current timestamp (with timezone).
+    CreatedAt,
+    /// When the row was updated. When used with the [crate::migration::schema::timestamps] method, will be initially set to
+    /// the current timestamp (with timezone).
+    ///
+    /// To automatically update the value for a row whenever the row is updated, include the
+    /// [m20240723_201404_add_update_timestamp_function::Migration]
+    /// in your [MigratorTrait] implementation, along with a [MigrationTrait] for your table
+    /// that add a trigger to update the column. Helper methods are provided for this in
+    /// the [crate::migration::timestamp] module. Specifically, see:
+    /// - [exec_create_update_timestamp_trigger]
+    /// - [exec_drop_update_timestamp_trigger]
+    ///
+    /// Note that the auto-updates mentioned above are currently only supported on Postgres. If
+    /// an app is using a different DB, it will need to manually update the timestamp when updating
+    /// a row.
+    UpdatedAt,
+}
+
 /// Wrapper around [create_update_timestamp_function] to execute the returned [Statement], if
 /// present.
 ///
 /// # Examples
 /// ```rust
-/// use roadster::migration::schema::Timestamps;
+/// use roadster::migration::timestamp::Timestamps;
 /// use roadster::migration::timestamp::exec_create_update_timestamp_function;
 /// use sea_orm_migration::prelude::*;
 ///
@@ -47,7 +71,7 @@ pub async fn exec_create_update_timestamp_function<C: IntoIden>(
 ///
 /// # Examples
 /// ```rust
-/// use roadster::migration::schema::Timestamps;
+/// use roadster::migration::timestamp::Timestamps;
 /// use roadster::migration::timestamp::{exec_create_update_timestamp_function_dep_column};
 /// use sea_orm_migration::prelude::*;
 ///
@@ -204,7 +228,7 @@ $$ language 'plpgsql';
 ///
 /// # Examples
 /// ```rust
-/// use roadster::migration::schema::Timestamps;
+/// use roadster::migration::timestamp::Timestamps;
 /// use roadster::migration::timestamp::exec_drop_update_timestamp_function;
 /// use sea_orm_migration::prelude::*;
 ///
@@ -269,7 +293,7 @@ fn drop_update_timestamp_function_for_db_backend<C: IntoIden>(
 ///
 /// # Examples
 /// ```rust
-/// use roadster::migration::schema::Timestamps;
+/// use roadster::migration::timestamp::Timestamps;
 /// use roadster::migration::timestamp::exec_create_update_timestamp_trigger;
 /// use sea_orm_migration::prelude::*;
 ///
@@ -359,7 +383,7 @@ EXECUTE PROCEDURE {fn_call};
 ///
 /// # Examples
 /// ```rust
-/// use roadster::migration::schema::Timestamps;
+/// use roadster::migration::timestamp::Timestamps;
 /// use roadster::migration::timestamp::exec_drop_update_timestamp_trigger;
 /// use sea_orm_migration::prelude::*;
 ///

--- a/src/migration/user/m20240724_005115_user_update_timestamp.rs
+++ b/src/migration/user/m20240724_005115_user_update_timestamp.rs
@@ -6,7 +6,7 @@
 //!
 //! Note: Currently only supports Postgres. If another DB is used, will do nothing.
 
-use crate::migration::schema::Timestamps;
+use crate::migration::timestamp::Timestamps;
 use crate::migration::timestamp::{
     exec_create_update_timestamp_trigger, exec_drop_update_timestamp_trigger,
 };

--- a/src/migration/user/mod.rs
+++ b/src/migration/user/mod.rs
@@ -14,7 +14,8 @@ mod tests;
 
 /// Contains the identifiers/fields created by all the `user` migrations.
 #[derive(DeriveIden)]
-pub(crate) enum User {
+#[non_exhaustive]
+pub enum User {
     Table,
     Id,
     Name,

--- a/src/migration/user/mod.rs
+++ b/src/migration/user/mod.rs
@@ -22,7 +22,7 @@ pub enum User {
     Username,
     Email,
     Password,
-    /// When the user's password was updated. Defaults to the[crate::migration::timestamp::Timestamps::UpdatedAt]
+    /// When the user's password was updated. Defaults to the [`UpdatedAt`][crate::migration::timestamp::Timestamps]
     /// time. Useful in the event users' passwords may have been compromised and the application
     /// needs to enforce that users update their passwords.
     ///


### PR DESCRIPTION
Making this public will enable consumers to create foreign-key constraints on fields created by the `UserMigrator`.