### PR TITLE
feat: Mark refresh token headers as sensitive

### DIFF
--- a/src/config/service/http/config/default.toml
+++ b/src/config/service/http/config/default.toml
@@ -4,11 +4,11 @@ default-enable = true
 
 [service.http.middleware.sensitive-request-headers]
 priority = -10000
-header-names = ["authorization", "proxy-authorization", "cookie", "set-cookie"]
+header-names = ["authorization", "refresh-token", "x-refresh-token", "proxy-authorization", "cookie", "set-cookie"]
 
 [service.http.middleware.sensitive-response-headers]
 priority = 10000
-header-names = ["authorization", "proxy-authorization", "cookie", "set-cookie"]
+header-names = ["authorization", "refresh-token", "x-refresh-token", "proxy-authorization", "cookie", "set-cookie"]
 
 [service.http.middleware.set-request-id]
 priority = -9990

--- a/src/config/snapshots/roadster__config__app_config__tests__test.snap
+++ b/src/config/snapshots/roadster__config__app_config__tests__test.snap
@@ -34,6 +34,8 @@ default-enable = true
 priority = -10000
 header-names = [
     'authorization',
+    'refresh-token',
+    'x-refresh-token',
     'proxy-authorization',
     'cookie',
     'set-cookie',
@@ -43,6 +45,8 @@ header-names = [
 priority = 10000
 header-names = [
     'authorization',
+    'refresh-token',
+    'x-refresh-token',
     'proxy-authorization',
     'cookie',
     'set-cookie',


### PR DESCRIPTION
These aren't standard headers, but we can provide them as a default in case they exist and we decide to make them a convention in Roadster in the future.