### PR TITLE
feat: Allow running CLI commands without requiring DB/Redis connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ axum = "0.7.4"
 schemars = "0.8.16"
 
 # DB
-sea-orm = { version = "1.0.0" }
+sea-orm = { version = "1.0.1" }
 sea-orm-migration = { version = "1.0.0" }
 
 # CLI

--- a/src/config/database/mod.rs
+++ b/src/config/database/mod.rs
@@ -1,3 +1,4 @@
+use crate::util::serde::default_true;
 use sea_orm::ConnectOptions;
 use serde_derive::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -18,6 +19,10 @@ pub struct Database {
     #[serde(default = "Database::default_connect_timeout")]
     #[serde_as(as = "serde_with::DurationMilliSeconds")]
     pub connect_timeout: Duration,
+    /// Whether to attempt to connect to the DB immediately upon creating the [`ConnectOptions`].
+    /// If `true` will wait to connect to the DB until the first DB query is attempted.
+    #[serde(default = "default_true")]
+    pub connect_lazy: bool,
     #[serde(default = "Database::default_acquire_timeout")]
     #[serde_as(as = "serde_with::DurationMilliSeconds")]
     pub acquire_timeout: Duration,
@@ -51,6 +56,7 @@ impl From<&Database> for ConnectOptions {
         let mut options = ConnectOptions::new(database.uri.to_string());
         options
             .connect_timeout(database.connect_timeout)
+            .connect_lazy(database.connect_lazy)
             .acquire_timeout(database.acquire_timeout)
             .min_connections(database.min_connections)
             .max_connections(database.max_connections)
@@ -111,6 +117,7 @@ mod deserialize_tests {
             uri: Url::parse("postgres://example:example@example:1234/example_app").unwrap(),
             auto_migrate: true,
             connect_timeout: Duration::from_secs(1),
+            connect_lazy: true,
             acquire_timeout: Duration::from_secs(2),
             idle_timeout: Some(Duration::from_secs(3)),
             max_lifetime: Some(Duration::from_secs(4)),

--- a/src/config/database/snapshots/roadster__config__database__deserialize_tests__db_config_to_connect_options.snap
+++ b/src/config/database/snapshots/roadster__config__database__deserialize_tests__db_config_to_connect_options.snap
@@ -29,5 +29,5 @@ ConnectOptions {
     sqlcipher_key: None,
     schema_search_path: None,
     test_before_acquire: true,
-    connect_lazy: false,
+    connect_lazy: true,
 }

--- a/src/config/database/snapshots/roadster__config__database__deserialize_tests__sidekiq@case_1.snap
+++ b/src/config/database/snapshots/roadster__config__database__deserialize_tests__sidekiq@case_1.snap
@@ -1,10 +1,11 @@
 ---
-source: src/config/database.rs
+source: src/config/database/mod.rs
 expression: database
 ---
 uri = 'https://example.com:1234/'
 auto-migrate = true
 connect-timeout = 1000
+connect-lazy = true
 acquire-timeout = 1000
 min-connections = 0
 max-connections = 1

--- a/src/config/database/snapshots/roadster__config__database__deserialize_tests__sidekiq@case_2.snap
+++ b/src/config/database/snapshots/roadster__config__database__deserialize_tests__sidekiq@case_2.snap
@@ -1,10 +1,11 @@
 ---
-source: src/config/database.rs
+source: src/config/database/mod.rs
 expression: database
 ---
 uri = 'https://example.com:1234/'
 auto-migrate = true
 connect-timeout = 1000
+connect-lazy = true
 acquire-timeout = 2000
 idle-timeout = 3000
 max-lifetime = 4000

--- a/src/config/snapshots/roadster__config__app_config__tests__test.snap
+++ b/src/config/snapshots/roadster__config__app_config__tests__test.snap
@@ -152,6 +152,7 @@ trace-propagation = true
 uri = 'postgres://example:example@invalid_host:5432/example_test'
 auto-migrate = true
 connect-timeout = 1000
+connect-lazy = true
 acquire-timeout = 1000
 min-connections = 0
 max-connections = 10


### PR DESCRIPTION
Sea-orm added support for lazy database connections. We provide a config field to allow toggling lazy database connections on or off. If lazy connections are enabled, the default `run` method will allow running CLI commands without requiring the the DB connection to be available (unless the CLI command itself attempts to execute a DB query).

Closes https://github.com/roadster-rs/roadster/issues/235