### PR TITLE
Update sea-orm to 1.1.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ axum = "0.7.4"
 schemars = "0.8.16"
 
 # DB
-sea-orm = { version = "1.0.1" }
+sea-orm = { version = "1.1.0-rc.1" }
 sea-orm-migration = { version = "1.0.0" }
 
 # CLI


### PR DESCRIPTION
sea-orm 1.1.0-rc.1 has sqlx 8.0, which allows consumers to update to the latest version of slqx which contains the fix for RUSTSEC-2024-0363

Closes https://github.com/roadster-rs/roadster/issues/335