### PR TITLE
chore: Revert "chore: Update Otel and tower-http dependencies (#374)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,15 +37,15 @@ dotenvy = "0.15.5"
 # Tracing
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
-opentelemetry-semantic-conventions = "0.25.0"
-opentelemetry = { version = "0.25.0", features = ["trace", "metrics", "logs"], optional = true }
-opentelemetry_sdk = { version = "0.25.0", features = ["tokio", "rt-tokio", "metrics", "logs", "trace"], optional = true }
-opentelemetry-otlp = { version = "0.25.0", features = ["metrics", "trace", "logs"], optional = true }
+opentelemetry-semantic-conventions = "0.16.0"
+opentelemetry = { version = "0.24.0", features = ["trace", "metrics", "logs"], optional = true }
+opentelemetry_sdk = { version = "0.24.1", features = ["tokio", "rt-tokio", "metrics", "logs", "trace"], optional = true }
+opentelemetry-otlp = { version = "0.17.0", features = ["metrics", "trace", "logs"], optional = true }
 # Roadster technically doesn't need a direct dependency on `prost`, but we add one here to allow our
 # `cargo minimal-versions check` check to pass -- `opentelemetry-proto` requires version `0.13.2` or higher
 # in order to compile -- it fails to compile with `0.13.1` even though its dependencies don't specify `0.13.2`.
 prost = { workspace = true, optional = true }
-tracing-opentelemetry = { version = "0.26.0", features = ["metrics"], optional = true }
+tracing-opentelemetry = { version = "0.25.0", features = ["metrics"], optional = true }
 
 # Controllers
 # `axum` is not optional because we use the `FromRef` trait pretty extensively, even in parts of
@@ -53,7 +53,7 @@ tracing-opentelemetry = { version = "0.26.0", features = ["metrics"], optional =
 axum = { workspace = true, features = ["macros"] }
 axum-extra = { version = "0.9.0", features = ["typed-header", "cookie"], optional = true }
 tower = { version = "0.5.0", optional = true }
-tower-http = { version = "0.6.0", features = ["trace", "timeout", "request-id", "util", "normalize-path", "sensitive-headers", "catch-panic", "compression-full", "decompression-full", "limit", "cors"], optional = true }
+tower-http = { version = "0.5.0", features = ["trace", "timeout", "request-id", "util", "normalize-path", "sensitive-headers", "catch-panic", "compression-full", "decompression-full", "limit", "cors"], optional = true }
 aide = { workspace = true, features = ["axum", "redoc", "scalar", "macros"], optional = true }
 schemars = { workspace = true, optional = true }
 http-body-util = "0.1.0"
@@ -153,7 +153,7 @@ rstest = { version = "0.22.0" }
 
 # Others
 # Todo: minimize tokio features included in `roadster`
-tokio = { version = "1.38.0", features = ["full"] }
+tokio = { version = "1.34.0", features = ["full"] }
 # For CancellationToken
 tokio-util = { version = "0.7.10" }
 anyhow = "1.0.86"


### PR DESCRIPTION
This reverts commit c6c699f5f16a9581cd5904f3ae6d14df0bd8876f.