### PR TITLE
chore: Disable default features for `rstest`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ rusty-sidekiq = { version = "0.10.5", default-features = false }
 
 # Testing
 insta = { version = "1.39.0", features = ["toml", "filters"] }
-rstest = { version = "0.22.0" }
+rstest = { version = "0.22.0", default-features = false }
 
 # Others
 # Todo: minimize tokio features included in `roadster`


### PR DESCRIPTION
For some reason, I'm getting an issue locally where the `rstest_macros` crate can't be found:

```
error[E0463]: can't find crate for rstest_macros
   --> /home/spencer/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rstest-0.22.0/src/lib.rs:570:9
    |
570 | pub use rstest_macros::fixture;
    |         ^^^^^^^^^^^^^ can't find crate
```

This doesn't occur in CI so I think something is wrong with my dev env. However, removing the default features from `rstest` seems to resolve this locally, and we don't need the default features in `roadster`.