### PR TITLE
feat: Add smtp client to `AppContext`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ clap = { version = "4.3.0", features = ["derive"] }
 # gRPC
 tonic = { version = "0.12.3" }
 prost = { version = "0.13.2" }
+tonic-build = { version = "0.12.3" }
 
 # Sidekiq
 # Todo: the default `rss-stats` feature has a dependency that currently can't be satisfied (memchr: ~2.3)
@@ -167,6 +168,8 @@ tokio-util = { version = "0.7.10" }
 anyhow = "1.0.86"
 serde = { version = "1.0.185", features = ["derive"] }
 cfg-if = "1.0.0"
+vergen = { version = "9.0.0" }
+vergen-gitcl = { version = "1.0.0" }
 
 [package.metadata.docs.rs]
 # Have docs.rs pass `--all-features` to ensure all features have their documentation built.

--- a/examples/app-builder/Cargo.toml
+++ b/examples/app-builder/Cargo.toml
@@ -38,9 +38,9 @@ rusty-sidekiq = { workspace = true, default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [build-dependencies]
-tonic-build = "0.12"
-vergen = { version = "9.0.0" }
-vergen-gitcl = { version = "1.0.0" }
+tonic-build = { workspace = true }
+vergen = { workspace = true }
+vergen-gitcl = { workspace = true }
 
 [[bin]]
 name = "app_builder"

--- a/examples/full/Cargo.toml
+++ b/examples/full/Cargo.toml
@@ -38,9 +38,9 @@ rusty-sidekiq = { workspace = true, default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [build-dependencies]
-tonic-build = "0.12"
-vergen = { version = "9.0.0" }
-vergen-gitcl = { version = "1.0.0" }
+tonic-build = { workspace = true }
+vergen = { workspace = true }
+vergen-gitcl = { workspace = true }
 
 [[bin]]
 name = "full"

--- a/examples/leptos-ssr/Cargo.toml
+++ b/examples/leptos-ssr/Cargo.toml
@@ -123,8 +123,8 @@ lib-default-features = false
 #lib-profile-release = "wasm-release"
 
 [build-dependencies]
-vergen = { version = "9.0.0" }
-vergen-gitcl = { version = "1.0.0" }
+vergen = { workspace = true }
+vergen-gitcl = { workspace = true }
 
 #[[bin]]
 #name = "leptos_ssr_example"

--- a/src/error/email.rs
+++ b/src/error/email.rs
@@ -1,0 +1,18 @@
+use crate::error::Error;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum EmailError {
+    #[cfg(feature = "email-smtp")]
+    #[error(transparent)]
+    Smtp(#[from] lettre::transport::smtp::Error),
+
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl From<lettre::transport::smtp::Error> for Error {
+    fn from(value: lettre::transport::smtp::Error) -> Self {
+        Self::Email(EmailError::from(value))
+    }
+}

--- a/src/error/email.rs
+++ b/src/error/email.rs
@@ -11,6 +11,7 @@ pub enum EmailError {
     Other(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
+#[cfg(feature = "email-smtp")]
 impl From<lettre::transport::smtp::Error> for Error {
     fn from(value: lettre::transport::smtp::Error) -> Self {
         Self::Email(EmailError::from(value))

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -3,6 +3,8 @@ pub mod auth;
 #[cfg(feature = "http")]
 pub mod axum;
 pub mod config;
+#[cfg(feature = "email")]
+pub mod email;
 pub mod other;
 pub mod serde;
 #[cfg(feature = "sidekiq")]
@@ -16,6 +18,8 @@ use crate::error::api::ApiError;
 use crate::error::auth::AuthError;
 #[cfg(feature = "http")]
 use crate::error::axum::AxumError;
+#[cfg(feature = "email")]
+use crate::error::email::EmailError;
 use crate::error::other::OtherError;
 use crate::error::serde::SerdeError;
 #[cfg(feature = "sidekiq")]
@@ -80,6 +84,10 @@ pub enum Error {
     #[cfg(feature = "grpc")]
     #[error(transparent)]
     Tonic(#[from] TonicError),
+
+    #[cfg(feature = "email")]
+    #[error(transparent)]
+    Email(#[from] EmailError),
 
     #[error(transparent)]
     Other(#[from] OtherError),


### PR DESCRIPTION
Use the smtp connection details from the `AppConfig::email::smtp` config to build an smtp client using the `lettre` crate.