### PR TITLE
feat: Allow configuring which req/res body content types to log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.74.1"
 
 [features]
 default = ["sidekiq", "db-sql", "open-api", "jwt-ietf", "cli", "otel"]
-http = ["dep:axum-extra", "dep:tower", "dep:tower-http"]
+http = ["dep:axum-extra", "dep:tower", "dep:tower-http", "dep:http-body-util", "dep:mime"]
 open-api = ["http", "dep:aide", "dep:schemars"]
 sidekiq = ["dep:rusty-sidekiq", "dep:bb8", "dep:num_cpus"]
 db-sql = ["dep:sea-orm", "dep:sea-orm-migration"]
@@ -54,12 +54,13 @@ tracing-opentelemetry = { version = "0.27.0", features = ["metrics"], optional =
 # `axum` is not optional because we use the `FromRef` trait pretty extensively, even in parts of
 # the code that wouldn't otherwise need `axum`.
 axum = { workspace = true, features = ["macros"] }
-axum-extra = { version = "0.9.0", features = ["typed-header", "cookie"], optional = true }
-tower = { version = "0.5.0", optional = true }
-tower-http = { version = "0.6.0", features = ["trace", "timeout", "request-id", "util", "normalize-path", "sensitive-headers", "catch-panic", "compression-full", "decompression-full", "limit", "cors"], optional = true }
+axum-extra = { workspace = true, features = ["typed-header", "cookie"], optional = true }
+tower = { workspace = true, optional = true }
+tower-http = { workspace = true, features = ["trace", "timeout", "request-id", "util", "normalize-path", "sensitive-headers", "catch-panic", "compression-full", "decompression-full", "limit", "cors"], optional = true }
 aide = { workspace = true, features = ["axum", "redoc", "scalar", "macros"], optional = true }
 schemars = { workspace = true, optional = true }
-http-body-util = "0.1.0"
+http-body-util = { version = "0.1.0", optional = true }
+mime = { workspace = true, optional = true }
 
 # DB
 sea-orm = { workspace = true, features = ["debug-print", "runtime-tokio-rustls", "sqlx-postgres", "macros"], optional = true }
@@ -138,7 +139,11 @@ async-trait = "0.1.74"
 # Controllers
 aide = { version = "0.13.4", features = ["axum"] }
 axum = "0.7.4"
+axum-extra = "0.9.0"
+tower-http = "0.6.0"
+tower = "0.5.0"
 schemars = "0.8.16"
+mime = "0.3.17"
 
 # DB
 sea-orm = { version = "1.0.1" }

--- a/examples/leptos-ssr/Cargo.toml
+++ b/examples/leptos-ssr/Cargo.toml
@@ -49,8 +49,8 @@ leptos_axum = { version = "0.6.14", optional = true }
 leptos_meta = { version = "0.6.14" }
 leptos_router = { version = "0.6.14" }
 leptos_config = { version = "0.6.14" }
-tower = { version = "0.5.0", features = ["full"], optional = true }
-tower-http = { version = "0.5", features = ["full"], optional = true }
+tower = { workspace = true, features = ["full"], optional = true }
+tower-http = { workspace = true, features = ["full"], optional = true }
 wasm-bindgen = "=0.2.93"
 
 # Defines a size-optimized profile for the WASM bundle in release mode

--- a/justfile
+++ b/justfile
@@ -5,7 +5,12 @@ help:
 # Run all of our unit tests.
 test:
     cargo nextest run --all-features --no-fail-fast
+
+test-doc:
     cargo test --doc --all-features --no-fail-fast
+
+# Run all of our unit tests.
+test-all: test test-doc
 
 # Run all of our unit tests whenever files in the repo change.
 test-watch:

--- a/src/error/axum.rs
+++ b/src/error/axum.rs
@@ -18,7 +18,6 @@ pub enum AxumError {
     #[error(transparent)]
     ToStrError(#[from] axum::http::header::ToStrError),
 
-    #[cfg(feature = "jwt")]
     #[error(transparent)]
     TypedHeaderRejection(#[from] axum_extra::typed_header::TypedHeaderRejection),
 

--- a/src/error/mime.rs
+++ b/src/error/mime.rs
@@ -1,0 +1,17 @@
+use crate::error::Error;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum MimeError {
+    #[error(transparent)]
+    FromStr(#[from] mime::FromStrError),
+
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl From<mime::FromStrError> for Error {
+    fn from(value: mime::FromStrError) -> Self {
+        Self::Mime(MimeError::from(value))
+    }
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -5,6 +5,8 @@ pub mod axum;
 pub mod config;
 #[cfg(feature = "email")]
 pub mod email;
+#[cfg(feature = "http")]
+pub mod mime;
 pub mod other;
 pub mod reqwest;
 pub mod serde;
@@ -21,6 +23,8 @@ use crate::error::auth::AuthError;
 use crate::error::axum::AxumError;
 #[cfg(feature = "email")]
 use crate::error::email::EmailError;
+#[cfg(feature = "http")]
+use crate::error::mime::MimeError;
 use crate::error::other::OtherError;
 use crate::error::reqwest::ReqwestError;
 use crate::error::serde::SerdeError;
@@ -85,6 +89,10 @@ pub enum Error {
     #[cfg(feature = "http")]
     #[error(transparent)]
     Axum(#[from] AxumError),
+
+    #[cfg(feature = "http")]
+    #[error(transparent)]
+    Mime(#[from] MimeError),
 
     #[cfg(feature = "grpc")]
     #[error(transparent)]

--- a/src/service/http/middleware/tracing/req_res_logging.rs
+++ b/src/service/http/middleware/tracing/req_res_logging.rs
@@ -4,19 +4,25 @@ use crate::app::context::AppContext;
 use crate::error::RoadsterResult;
 use crate::service::http::middleware::Middleware;
 use axum::body::{Body, Bytes};
-use axum::extract::{FromRef, Request};
-use axum::http::StatusCode;
+use axum::extract::{FromRef, Request, State};
+use axum::http::header::CONTENT_TYPE;
+use axum::http::{HeaderValue, StatusCode};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum::{middleware, Router};
 use http_body_util::BodyExt;
+use mime::Mime;
 use serde_derive::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+use std::collections::BTreeSet;
+use std::str::FromStr;
 use tracing::debug;
 use validator::Validate;
 
 pub use RequestResponseLoggingConfig as ReqResLoggingConfig;
 pub use RequestResponseLoggingMiddleware as RequestLoggingMiddleware;
 
+#[serde_as]
 #[derive(Debug, Clone, Default, Validate, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default)]
 #[non_exhaustive]
@@ -24,6 +30,33 @@ pub struct RequestResponseLoggingConfig {
     /// The maximum length to log. Payloads longer than this length will be truncated. To log the
     /// entire payload without any truncating, set to a negative number.
     pub max_len: i32,
+
+    /// The content types to log. If not provided, all content types will be logged unless
+    /// otherwise specified via `content_types_req` or `content_types_res`.
+    ///
+    /// Note: this currently only supports exact matches, so using `text/*` will not match
+    /// `text/plain`, for example.
+    #[serde_as(as = "Option<BTreeSet<DisplayFromStr>>")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_types: Option<BTreeSet<Mime>>,
+
+    /// The request payload content types to log. If not provided, will fall back to the
+    /// values from `content_types`.
+    ///
+    /// Note: this currently only supports exact matches, so using `text/*` will not match
+    /// `text/plain`, for example.
+    #[serde_as(as = "Option<BTreeSet<DisplayFromStr>>")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_types_req: Option<BTreeSet<Mime>>,
+
+    /// The response payload content types to log. If not provided, will fall back to the
+    /// values from `content_types`.
+    ///
+    /// Note: this currently only supports exact matches, so using `text/*` will not match
+    /// `text/plain`, for example.
+    #[serde_as(as = "Option<BTreeSet<DisplayFromStr>>")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_types_res: Option<BTreeSet<Mime>>,
 }
 
 pub struct RequestResponseLoggingMiddleware;
@@ -71,40 +104,140 @@ where
             .custom
             .max_len;
 
-        let router = router.layer(middleware::from_fn(move |request, next| {
-            log_req_res_bodies(request, next, max_len)
-        }));
+        let router = router.layer(middleware::from_fn_with_state(
+            state.clone(),
+            move |State(state): State<S>, request, next| {
+                log_req_res_bodies(state, request, next, max_len)
+            },
+        ));
 
         Ok(router)
     }
 }
 
+const TRUNCATED_STR: &str = "[truncated according to the `service.http.middleware.request-response-logging.max-len` config]";
+const CONTENT_TYPE_OMITTED_STR: &str = "[omitted according to the `service.http.middleware.request-response-logging.content_types*` configs]";
+
 // https://github.com/tokio-rs/axum/blob/main/examples/consume-body-in-extractor-or-middleware/src/main.rs
-async fn log_req_res_bodies(
+async fn log_req_res_bodies<S>(
+    state: S,
     request: Request,
     next: Next,
     max_len: i32,
-) -> Result<impl IntoResponse, Response> {
+) -> Result<impl IntoResponse, Response>
+where
+    S: Clone + Send + Sync + 'static,
+    AppContext: FromRef<S>,
+{
+    let context = AppContext::from_ref(&state);
+    let config = &context
+        .config()
+        .service
+        .http
+        .custom
+        .middleware
+        .request_response_logging
+        .custom;
+
     // Log the request body
+    let is_req = true;
     let (parts, body) = request.into_parts();
-    let bytes = log_body(body, max_len, true).await?;
-    let request = Request::from_parts(parts, Body::from(bytes));
+    let content_type = get_content_type(parts.headers.get(CONTENT_TYPE))
+        .ok()
+        .flatten();
+    let body = if should_log_content_type(config, content_type.as_ref(), is_req).unwrap_or_default()
+    {
+        let bytes = log_body(body, max_len, is_req).await?;
+        Body::from(bytes)
+    } else {
+        let content_type = content_type
+            .as_ref()
+            .map(|content_type| content_type.as_ref())
+            .unwrap_or_default();
+        debug!(content_type, body = CONTENT_TYPE_OMITTED_STR, "request");
+        body
+    };
+    let request = Request::from_parts(parts, body);
 
     // Handle the request
     let response = next.run(request).await;
 
     // Log the response body
+    let is_req = false;
     let (parts, body) = response.into_parts();
-    let bytes = log_body(body, max_len, false).await?;
-    let response = Response::from_parts(parts, Body::from(bytes));
+    let content_type = get_content_type(parts.headers.get(CONTENT_TYPE))
+        .ok()
+        .flatten();
+    let body = if should_log_content_type(config, content_type.as_ref(), is_req).unwrap_or_default()
+    {
+        let bytes = log_body(body, max_len, is_req).await?;
+        Body::from(bytes)
+    } else {
+        let content_type = content_type
+            .as_ref()
+            .map(|content_type| content_type.as_ref())
+            .unwrap_or_default();
+        debug!(content_type, body = CONTENT_TYPE_OMITTED_STR, "response");
+        body
+    };
+    let response = Response::from_parts(parts, body);
 
     // Return the response
     Ok(response)
 }
 
-const TRUNCATED_STR: &str = "[truncated according to the `service.http.middleware.request-response-logging.max-len` config]";
+fn get_content_type(content_type: Option<&HeaderValue>) -> RoadsterResult<Option<Mime>> {
+    if let Some(content_type) = content_type {
+        Ok(Some(Mime::from_str(content_type.to_str()?)?))
+    } else {
+        Ok(None)
+    }
+}
 
-async fn log_body(body: Body, max_len: i32, req: bool) -> Result<Bytes, Response> {
+fn should_log_content_type(
+    config: &RequestResponseLoggingConfig,
+    content_type: Option<&Mime>,
+    is_req: bool,
+) -> RoadsterResult<bool> {
+    let config = if is_req {
+        (
+            config.content_types.as_ref(),
+            config.content_types_req.as_ref(),
+        )
+    } else {
+        (
+            config.content_types.as_ref(),
+            config.content_types_res.as_ref(),
+        )
+    };
+    // Todo: Is there a cleaner way to write this?
+    match config {
+        (Some(a), Some(b)) => {
+            if let Some(content_type) = content_type {
+                Ok(a.contains(content_type) || b.contains(content_type))
+            } else {
+                Ok(false)
+            }
+        }
+        (None, Some(a)) => {
+            if let Some(content_type) = content_type {
+                Ok(a.contains(content_type))
+            } else {
+                Ok(false)
+            }
+        }
+        (Some(a), None) => {
+            if let Some(content_type) = content_type {
+                Ok(a.contains(content_type))
+            } else {
+                Ok(false)
+            }
+        }
+        (None, None) => Ok(true),
+    }
+}
+
+async fn log_body(body: Body, max_len: i32, is_req: bool) -> Result<Bytes, Response> {
     // This only works if the body is not a long-running stream
     let bytes = body
         .collect()
@@ -122,7 +255,7 @@ async fn log_body(body: Body, max_len: i32, req: bool) -> Result<Bytes, Response
         format!("{slice:?}{TRUNCATED_STR}")
     };
 
-    if req {
+    if is_req {
         debug!(body, "request");
     } else {
         debug!(body, "response");
@@ -190,5 +323,174 @@ mod tests {
 
         // Act/Assert
         assert_eq!(middleware.priority(&context), expected_priority);
+    }
+
+    #[rstest]
+    #[case(
+        r#"
+        max-len = -1
+        "#,
+        None,
+        true,
+        true
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types = []
+        "#,
+        None,
+        true,
+        false
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types = []
+        "#,
+        None,
+        false,
+        false
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types-req = []
+        "#,
+        None,
+        true,
+        false
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types-res = []
+        "#,
+        None,
+        true,
+        true
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types-req = []
+        "#,
+        None,
+        false,
+        true
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types-res = []
+        "#,
+        None,
+        false,
+        false
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types = ["text/plain"]
+        "#,
+        Some("text/plain"),
+        true,
+        true
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types = ["text/plain"]
+        "#,
+        Some("text/plain"),
+        false,
+        true
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types-req = ["text/plain"]
+        "#,
+        Some("text/plain"),
+        true,
+        true
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types-res = ["text/plain"]
+        "#,
+        Some("text/plain"),
+        false,
+        true
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types = ["application/json"]
+        "#,
+        Some("text/html"),
+        true,
+        false
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types = ["application/json"]
+        "#,
+        Some("text/html"),
+        false,
+        false
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types-req = ["application/json"]
+        "#,
+        Some("text/html"),
+        true,
+        false
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types-req = ["application/json"]
+        "#,
+        Some("text/html"),
+        false,
+        true
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types-res = ["application/json"]
+        "#,
+        Some("text/html"),
+        true,
+        true
+    )]
+    #[case(
+        r#"
+        max-len = -1
+        content-types-res = ["application/json"]
+        "#,
+        Some("text/html"),
+        false,
+        false
+    )]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn should_log_content_type(
+        #[case] config: &str,
+        #[case] content_type: Option<&str>,
+        #[case] is_req: bool,
+        #[case] expected: bool,
+    ) {
+        let config: RequestResponseLoggingConfig = toml::from_str(config).unwrap();
+        let content_type = content_type.map(|s| Mime::from_str(s).unwrap());
+
+        let should_log =
+            super::should_log_content_type(&config, content_type.as_ref(), is_req).unwrap();
+
+        assert_eq!(should_log, expected);
     }
 }


### PR DESCRIPTION
Some req/res body content types are more useful to log than others. For example, it's not generally helpful to log `image/x-icon` or `text/javascript`. However, it can still be very useful for debugging to log things like `application/json` or
`application/x-www-form-urlencoded`.

Allow configuring which content types to allow to be logged. By default, all content types are allowed. Currently, only exact matches of content types are supported, so using `text/*` will not match `text/plain`, for example.

Closes https://github.com/roadster-rs/roadster/issues/390