### PR TITLE
ci: Test mdbook before deploying

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,10 +1,11 @@
-# Copied from https://github.com/leptos-rs/book/blob/f6683d42f2a9f67230cfdf9fb94e094f1c8bfca4/.github/workflows/publish_mdbook.yml#L1
+# Originally copied from https://github.com/leptos-rs/book/blob/f6683d42f2a9f67230cfdf9fb94e094f1c8bfca4/.github/workflows/publish_mdbook.yml#L1
 
-name: Deploy Book to Github Pages
+name: Book
 
 on:
-  # Runs on pushes targeting the default branch
   push:
+    branches: [ main ]
+  pull_request:
     branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
@@ -22,18 +23,31 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  MDBOOK_VERSION: 0.4.40
+
 jobs:
+  test-book:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@mdbook
+      - uses: taiki-e/install-action@just
 
-  # Job: Build and Deploy to Pages
-  build-and-deploy:
+      - name: Test mdbook
+        run: just test-book
 
+      - name: Test mdbook examples
+        run: just test-book-examples
+
+  build-and-deploy-book:
+    # Only deploy on pushes to `main` or manual workflow dispatches
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    needs: test-book
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-
-    runs-on: ubuntu-latest
-    env:
-      MDBOOK_VERSION: 0.4.40
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@mdbook
@@ -42,10 +56,8 @@ jobs:
         id: pages
         uses: actions/configure-pages@v4
 
-      - name: Build with mdBook
-        run: |
-          cd ./book
-          mdbook build
+      - name: Build
+        run: mdbook build book
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,30 @@ jobs:
   # `cargo hack --each-feature` runs the given command for each feature, including "no features", "all features",
   # and the `default` feature.
   build:
-    name: Build
+    name: Build each feature
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-hack
-      - uses: taiki-e/install-action@nextest
       # protoc is needed to build examples that have grpc enabled
       - uses: taiki-e/install-action@protoc
       - name: Build
-        run: cargo hack build --each-feature --workspace --clean-per-run --log-group github-actions
+        run: cargo hack build --each-feature --clean-per-run --log-group github-actions
+
+  test-examples:
+    name: Test examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rui314/setup-mold@v1
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@just
+      # protoc is needed to build examples that have grpc enabled
+      - uses: taiki-e/install-action@protoc
+      - name: Test
+        run: just test-examples
 
   test:
     name: Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ mockall_double = "0.3.1"
 rstest = { workspace = true }
 
 [workspace]
-members = [".", "examples/*"]
+members = [".", "examples/*", "book/examples/*"]
 
 [workspace.dependencies]
 # Tracing

--- a/book/book.toml
+++ b/book/book.toml
@@ -4,3 +4,6 @@ language = "en"
 multilingual = false
 src = "src"
 title = "Roadster"
+
+[rust]
+edition = "2021"

--- a/book/examples/chapter_1/Cargo.toml
+++ b/book/examples/chapter_1/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "chapter-1"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+roadster = { path = "../../.." }

--- a/book/examples/chapter_1/src/main.rs
+++ b/book/examples/chapter_1/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Test of including a rust snippet in mdbook.");
+}

--- a/book/src/chapter_1.md
+++ b/book/src/chapter_1.md
@@ -1,3 +1,7 @@
 # Chapter 1
 
 mdBook docs are in progress. For now, use the [doc.rs documentation](https://docs.rs/roadster/latest/roadster/).
+
+```rust
+{{#rustdoc_include ../examples/chapter_1/src/main.rs}}
+```

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ test-doc:
     cargo test --doc --all-features --no-fail-fast
 
 test-examples:
-    for dir in ./examples/*/; do pushd $dir && cargo test --all-features --no-fail-fast && popd; done
+    for dir in ./examples/*/; do cd $dir && pwd && cargo test --all-features --no-fail-fast && cd ../.. && pwd; done
 
 # Run all of our unit tests.
 test-unit: test test-doc
@@ -19,7 +19,7 @@ test-book:
     mdbook test book
 
 test-book-examples:
-    for dir in ./book/examples/*/; do pushd $dir && cargo test --all-features --no-fail-fast && popd; done
+    for dir in ./book/examples/*/; do cd $dir && pwd && cargo test --all-features --no-fail-fast && cd ../../.. && pwd; done
 
 test-book-all: test-book test-book-examples
 

--- a/justfile
+++ b/justfile
@@ -9,8 +9,22 @@ test:
 test-doc:
     cargo test --doc --all-features --no-fail-fast
 
+test-examples:
+    for dir in ./examples/*/; do pushd $dir && cargo test --all-features --no-fail-fast && popd; done
+
 # Run all of our unit tests.
-test-all: test test-doc
+test-unit: test test-doc
+
+test-book:
+    mdbook test book
+
+test-book-examples:
+    for dir in ./book/examples/*/; do pushd $dir && cargo test --all-features --no-fail-fast && popd; done
+
+test-book-all: test-book test-book-examples
+
+# Run all of our tests
+test-all: test-unit test-book-all
 
 # Run all of our unit tests whenever files in the repo change.
 test-watch:
@@ -55,4 +69,4 @@ validate-codecov-config:
 
 # Initialize a new installation of the repo (e.g., install deps)
 init:
-    cargo binstall cargo-nextest cargo-llvm-cov sea-orm-cli cargo-insta cargo-minimal-versions cargo-hack
+    cargo binstall cargo-nextest cargo-llvm-cov sea-orm-cli cargo-insta cargo-minimal-versions cargo-hack mdbook


### PR DESCRIPTION
- Enable including rust snippets from other files in mdbook
- Run tests against book examples in ci
- Run `mdbook test` in ci
- Add some justfile commands to contain testing logic -- we're manually iterating over workspace members instead of using cargo's workspace features