### PR TITLE
ci: Remove `build` step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,21 +10,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # `cargo hack --each-feature` runs the given command for each feature, including "no features", "all features",
-  # and the `default` feature.
-  build:
-    name: Build each feature
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: rui314/setup-mold@v1
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@cargo-hack
-      # protoc is needed to build examples that have grpc enabled
-      - uses: taiki-e/install-action@protoc
-      - name: Build
-        run: cargo hack build --each-feature --clean-per-run --log-group github-actions
-
   test-examples:
     name: Test examples
     runs-on: ubuntu-latest


### PR DESCRIPTION
This step was previously building with --each-feature and --workspace args. However, we're testing the --workspace part in a separate step, so this is not pretty much redundant with the `test` step.