### PR TITLE
feat: Add `AnyInitializer` to minimize boilerplate for initializers

### DIFF
--- a/examples/full/src/api/http/mod.rs
+++ b/examples/full/src/api/http/mod.rs
@@ -3,8 +3,6 @@ use aide::axum::ApiRouter;
 use axum::extract::Request;
 use axum::middleware::Next;
 use axum::response::Response;
-use roadster::service::http::middleware::any::AnyMiddleware;
-use roadster::service::http::middleware::Middleware;
 use tracing::info;
 
 pub mod example;

--- a/src/service/http/builder.rs
+++ b/src/service/http/builder.rs
@@ -196,12 +196,14 @@ where
         let router = initializers
             .iter()
             .try_fold(router, |router, initializer| {
+                info!(name=%initializer.name(), "Running Initializer::after_router");
                 initializer.after_router(router, state)
             })?;
 
         let router = initializers
             .iter()
             .try_fold(router, |router, initializer| {
+                info!(name=%initializer.name(), "Running Initializer::before_middleware");
                 initializer.before_middleware(router, state)
             })?;
 
@@ -221,12 +223,14 @@ where
         let router = initializers
             .iter()
             .try_fold(router, |router, initializer| {
+                info!(name=%initializer.name(), "Running Initializer::after_middleware");
                 initializer.after_middleware(router, state)
             })?;
 
         let router = initializers
             .iter()
             .try_fold(router, |router, initializer| {
+                info!(name=%initializer.name(), "Running Initializer::before_serve");
                 initializer.before_serve(router, state)
             })?;
 

--- a/src/service/http/initializer/any.rs
+++ b/src/service/http/initializer/any.rs
@@ -1,13 +1,12 @@
 use crate::app::context::AppContext;
 use crate::error::RoadsterResult;
-use crate::service::http::middleware::Middleware;
+use crate::service::http::initializer::Initializer;
 use axum::Router;
 use axum_core::extract::FromRef;
 use typed_builder::TypedBuilder;
 
 #[derive(TypedBuilder)]
-#[non_exhaustive]
-pub struct AnyMiddleware<S>
+pub struct AnyInitializer<S>
 where
     S: Clone + Send + Sync + 'static,
     AppContext: FromRef<S>,
@@ -18,8 +17,20 @@ where
     enabled: Option<bool>,
     #[builder(default, setter(strip_option))]
     priority: Option<i32>,
+    #[builder(default, setter(strip_option))]
+    stage: Option<Stage>,
     #[builder(setter(transform = |a: impl Fn(Router, &S) -> RoadsterResult<Router> + Send + 'static| to_box_fn(a) ))]
     apply: Box<dyn Fn(Router, &S) -> RoadsterResult<Router> + Send>,
+}
+
+#[derive(Default)]
+#[non_exhaustive]
+pub enum Stage {
+    AfterRouter,
+    BeforeMiddleware,
+    AfterMiddleware,
+    #[default]
+    BeforeServe,
 }
 
 fn to_box_fn<S>(
@@ -28,7 +39,7 @@ fn to_box_fn<S>(
     Box::new(p)
 }
 
-impl<S> Middleware<S> for AnyMiddleware<S>
+impl<S> Initializer<S> for AnyInitializer<S>
 where
     S: Clone + Send + Sync + 'static,
     AppContext: FromRef<S>,
@@ -44,7 +55,7 @@ where
             .service
             .http
             .custom
-            .middleware
+            .initializer
             .custom
             .get(&self.name);
         if let Some(config) = config {
@@ -55,7 +66,7 @@ where
                 .service
                 .http
                 .custom
-                .middleware
+                .initializer
                 .default_enable
                 || self.enabled.unwrap_or_default()
         }
@@ -67,14 +78,42 @@ where
             .service
             .http
             .custom
-            .middleware
+            .initializer
             .custom
             .get(&self.name)
             .map(|config| config.common.priority)
             .unwrap_or_else(|| self.priority.unwrap_or_default())
     }
 
-    fn install(&self, router: Router, state: &S) -> RoadsterResult<Router> {
-        (self.apply)(router, state)
+    fn after_router(&self, router: Router, _state: &S) -> RoadsterResult<Router> {
+        if let Some(Stage::AfterRouter) = self.stage {
+            (self.apply)(router, _state)
+        } else {
+            Ok(router)
+        }
+    }
+
+    fn before_middleware(&self, router: Router, _state: &S) -> RoadsterResult<Router> {
+        if let Some(Stage::BeforeMiddleware) = self.stage {
+            (self.apply)(router, _state)
+        } else {
+            Ok(router)
+        }
+    }
+
+    fn after_middleware(&self, router: Router, _state: &S) -> RoadsterResult<Router> {
+        if let Some(Stage::AfterMiddleware) = self.stage {
+            (self.apply)(router, _state)
+        } else {
+            Ok(router)
+        }
+    }
+
+    fn before_serve(&self, router: Router, _state: &S) -> RoadsterResult<Router> {
+        if let Some(Stage::BeforeServe) = self.stage {
+            (self.apply)(router, _state)
+        } else {
+            Ok(router)
+        }
     }
 }

--- a/src/service/http/initializer/mod.rs
+++ b/src/service/http/initializer/mod.rs
@@ -1,3 +1,4 @@
+pub mod any;
 pub mod default;
 pub mod normalize_path;
 


### PR DESCRIPTION
If a consumer wants to initialize the Axum Router in a way that's not already supported by Roadster, they need to implement the `Initializer` trait, which is extra boilerplate that could be annoying.

Add `AnyInitializer` struct that implements the `Initializer` trait, so consumers just need to provide the name of the initializer and the logic to build/configure the Axum Router.

Note: This PR also contains a breaking change to `AnyMiddleware`. However, since this was just released a few hours ago, I doubt anyone is using it yet, so it should be relatively safe to just release the breaking change in a patch update.

Closes https://github.com/roadster-rs/roadster/issues/473