### PR TITLE
feat: Add support for TestContainers (pgsql + redis modules)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ jwt-openid = ["jwt"]
 cli = ["dep:clap"]
 otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry", "dep:prost"]
 grpc = ["dep:tonic"]
-testing = ["dep:insta", "dep:rstest"]
+testing = ["dep:insta", "dep:rstest", "dep:testcontainers-modules"]
+test-containers = ["testing", "dep:testcontainers-modules"]
 config-yml = ["config/yaml"]
 
 [dependencies]
@@ -94,13 +95,14 @@ tonic = { workspace = true, optional = true }
 # Testing
 insta = { workspace = true, optional = true }
 rstest = { workspace = true, optional = true }
+testcontainers-modules = { workspace = true, features = ["postgres", "redis"], optional = true }
 
 # Others
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
-serde_with = { version = "3.0.0", features = ["macros", "chrono_0_4"] }
+serde_with = { version = "3.7.0", features = ["macros", "chrono_0_4"] }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 itertools = { workspace = true }
@@ -171,6 +173,7 @@ rusty-sidekiq = { version = "0.11.0", default-features = false }
 # Testing
 insta = { version = "1.39.0", features = ["toml", "filters"] }
 rstest = { version = "0.23.0", default-features = false }
+testcontainers-modules = { version = "0.11.3" }
 
 # Others
 # Todo: minimize tokio features included in `roadster`

--- a/src/config/database/mod.rs
+++ b/src/config/database/mod.rs
@@ -13,26 +13,41 @@ use validator::Validate;
 pub struct Database {
     /// This can be overridden with an environment variable, e.g. `ROADSTER__DATABASE__URI=postgres://example:example@example:1234/example_app`
     pub uri: Url,
+
     /// Whether to automatically apply migrations during the app's start up. Migrations can also
     /// be manually performed via the `roadster migration [COMMAND]` CLI command.
     pub auto_migrate: bool,
+
     #[serde(default = "Database::default_connect_timeout")]
     #[serde_as(as = "serde_with::DurationMilliSeconds")]
     pub connect_timeout: Duration,
+
     /// Whether to attempt to connect to the DB immediately upon creating the [`ConnectOptions`].
     /// If `true` will wait to connect to the DB until the first DB query is attempted.
     #[serde(default = "default_true")]
     pub connect_lazy: bool,
+
     #[serde(default = "Database::default_acquire_timeout")]
     #[serde_as(as = "serde_with::DurationMilliSeconds")]
     pub acquire_timeout: Duration,
+
     #[serde_as(as = "Option<serde_with::DurationSeconds>")]
     pub idle_timeout: Option<Duration>,
+
     #[serde_as(as = "Option<serde_with::DurationSeconds>")]
     pub max_lifetime: Option<Duration>,
+
     #[serde(default)]
     pub min_connections: u32,
+
     pub max_connections: u32,
+
+    /// Options for creating a Test Container instance for the DB. If enabled, the `Database#uri`
+    /// field will be overridden to be the URI for the Test Container instance that's created when
+    /// building the app's [`crate::app::context::AppContext`].
+    #[cfg(feature = "test-containers")]
+    #[serde(default)]
+    pub test_container: Option<crate::config::TestContainer>,
 }
 
 impl Database {
@@ -115,6 +130,8 @@ mod tests {
     fn db_config_to_connect_options() {
         let db = Database {
             uri: Url::parse("postgres://example:example@example:1234/example_app").unwrap(),
+            #[cfg(feature = "test-containers")]
+            test_container: None,
             auto_migrate: true,
             connect_timeout: Duration::from_secs(1),
             connect_lazy: true,

--- a/src/config/service/worker/sidekiq/mod.rs
+++ b/src/config/service/worker/sidekiq/mod.rs
@@ -84,15 +84,24 @@ pub enum StaleCleanUpBehavior {
 #[non_exhaustive]
 pub struct Redis {
     pub uri: Url,
+
     /// The configuration for the Redis connection pool used for enqueuing Sidekiq jobs in Redis.
     #[serde(default)]
     #[validate(nested)]
     pub enqueue_pool: ConnectionPool,
+
     /// The configuration for the Redis connection pool used by [sidekiq::Processor] to fetch
     /// Sidekiq jobs from Redis.
     #[serde(default)]
     #[validate(nested)]
     pub fetch_pool: ConnectionPool,
+
+    /// Options for creating a Test Container instance for the DB. If enabled, the `Redis#uri`
+    /// field will be overridden to be the URI for the Test Container instance that's created when
+    /// building the app's [`crate::app::context::AppContext`].
+    #[cfg(feature = "test-containers")]
+    #[serde(default)]
+    pub test_container: Option<crate::config::TestContainer>,
 }
 
 #[derive(Debug, Default, Validate, Clone, Serialize, Deserialize)]

--- a/src/service/runner.rs
+++ b/src/service/runner.rs
@@ -1,9 +1,10 @@
 #[cfg(feature = "cli")]
 use crate::api::cli::roadster::RoadsterCli;
-use crate::api::core::health::health_check;
+use crate::api::core::health::health_check_with_checks;
 use crate::app::context::AppContext;
 use crate::app::App;
 use crate::error::RoadsterResult;
+use crate::health_check::HealthCheck;
 use crate::health_check::Status;
 use crate::service::registry::ServiceRegistry;
 use anyhow::anyhow;
@@ -38,9 +39,9 @@ where
 }
 
 #[instrument(skip_all)]
-pub(crate) async fn health_checks(context: &AppContext) -> RoadsterResult<()> {
+pub(crate) async fn health_checks(checks: Vec<Arc<dyn HealthCheck>>) -> RoadsterResult<()> {
     let duration = Duration::from_secs(60);
-    let response = health_check(context, Some(duration)).await?;
+    let response = health_check_with_checks(checks, Some(duration)).await?;
 
     let error_responses = response
         .resources


### PR DESCRIPTION
Add support for TestContainers to make it easy to set up independent test environments to allow running tests in parallel without risk of cross-contamination even if they touch the DB.

TestContainers support is behind the `test-containers` flag. When the flag is enabled, the consumer can enable TestContainers for the DB and Sidekiq Redis in the `AppConfig`, in which case a TestContainer instance will be create when building the `AppContext`, and the URI in the `AppConfig` will be updated to match that of the TestContainer instance.

Additionally, a new method was added to `AppConfig` to allow consumers to create it themselves. This would allow consumers more control over the config, including manually creating a TestContainer instance and updating the URI of a field in the `AppConfig` before loading the application.

Finally, a new `app::init_state` method was added to allow getting access to a real `AppState` instance in tests. This method performs most of the setup of the app without actually running the app. This is similar but slightly different to the existing `app::prepare` method, and is intended to only be used in tests.

Closes https://github.com/roadster-rs/roadster/issues/500