### PR TITLE
feat: `Provide` and `ProvideRef` traits to provide `AppContext` objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", 
 grpc = ["dep:tonic"]
 testing = ["dep:insta", "dep:rstest", "dep:testcontainers-modules"]
 test-containers = ["testing", "dep:testcontainers-modules"]
+testing-mocks = ["testing", "dep:mockall"]
 config-yml = ["config/yaml"]
 
 [dependencies]
@@ -96,6 +97,7 @@ tonic = { workspace = true, optional = true }
 insta = { workspace = true, optional = true }
 rstest = { workspace = true, optional = true }
 testcontainers-modules = { workspace = true, features = ["postgres", "redis"], optional = true }
+mockall = { workspace = true, optional = true }
 
 # Others
 anyhow = { workspace = true }
@@ -128,7 +130,7 @@ reqwest = { workspace = true }
 [dev-dependencies]
 cargo-husky = { version = "1.5.0", default-features = false, features = ["user-hooks"] }
 insta = { workspace = true, features = ["json"] }
-mockall = "0.13.0"
+mockall = { workspace = true }
 mockall_double = "0.3.1"
 rstest = { workspace = true }
 
@@ -174,6 +176,7 @@ rusty-sidekiq = { version = "0.11.0", default-features = false }
 insta = { version = "1.39.0", features = ["toml", "filters"] }
 rstest = { version = "0.23.0", default-features = false }
 testcontainers-modules = { version = "0.11.3" }
+mockall = "0.13.0"
 
 # Others
 # Todo: minimize tokio features included in `roadster`

--- a/examples/full/src/app_state.rs
+++ b/examples/full/src/app_state.rs
@@ -1,7 +1,26 @@
 use axum::extract::FromRef;
 use roadster::app::context::AppContext;
+use roadster::app::context::{Provide, ProvideRef};
 
 #[derive(Clone, FromRef)]
 pub struct AppState {
     pub app_context: AppContext,
+}
+
+impl<T> Provide<T> for AppState
+where
+    AppContext: Provide<T>,
+{
+    fn provide(&self) -> T {
+        Provide::provide(&self.app_context)
+    }
+}
+
+impl<T> ProvideRef<T> for AppState
+where
+    AppContext: ProvideRef<T>,
+{
+    fn provide(&self) -> &T {
+        ProvideRef::provide(&self.app_context)
+    }
 }


### PR DESCRIPTION
Also, annotate with `mockall::automock` when the new `testing-mocks` feature is enabled to allow consumers to easily provide mocks to methods expecting a trait impl.

This is significantly simpler than mocking the `AppContext` struct itself, so we will not do that for now. We can consider doing it later if people really want it.

Closes https://github.com/roadster-rs/roadster/issues/495