### PR TITLE
feat: Add `AppContextWeak` to prevent reference cycles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,8 +153,8 @@ schemars = "0.8.16"
 mime = "0.3.17"
 
 # DB
-sea-orm = { version = "1.1.0" }
-sea-orm-migration = { version = "1.1.0" }
+sea-orm = { version = "1.1.2" }
+sea-orm-migration = { version = "1.1.2" }
 
 # Email
 lettre = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["web", "framework"]
 categories = ["web-programming", "web-programming::http-server"]
 # Determined using `cargo msrv` -- https://github.com/foresterre/cargo-msrv
-rust-version = "1.77.2"
+rust-version = "1.81"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/health_check/database.rs
+++ b/src/health_check/database.rs
@@ -1,12 +1,12 @@
 use crate::api::core::health::db_health;
-use crate::app::context::AppContext;
+use crate::app::context::{AppContext, AppContextWeak};
 use crate::error::RoadsterResult;
-use crate::health_check::{CheckResponse, HealthCheck};
+use crate::health_check::{missing_context_response, CheckResponse, HealthCheck};
 use async_trait::async_trait;
 use tracing::instrument;
 
 pub struct DatabaseHealthCheck {
-    pub(crate) context: AppContext,
+    pub(crate) context: AppContextWeak,
 }
 
 #[async_trait]
@@ -16,12 +16,20 @@ impl HealthCheck for DatabaseHealthCheck {
     }
 
     fn enabled(&self) -> bool {
-        enabled(&self.context)
+        self.context
+            .upgrade()
+            .map(|context| enabled(&context))
+            .unwrap_or_default()
     }
 
     #[instrument(skip_all)]
     async fn check(&self) -> RoadsterResult<CheckResponse> {
-        Ok(db_health(&self.context, None).await)
+        let context = self.context.upgrade();
+        let response = match context {
+            Some(context) => db_health(&context, None).await,
+            None => missing_context_response(),
+        };
+        Ok(response)
     }
 }
 

--- a/src/health_check/default.rs
+++ b/src/health_check/default.rs
@@ -17,19 +17,19 @@ pub fn default_health_checks(
     let health_checks: Vec<Arc<dyn HealthCheck>> = vec![
         #[cfg(feature = "db-sql")]
         Arc::new(DatabaseHealthCheck {
-            context: context.clone(),
+            context: context.downgrade(),
         }),
         #[cfg(feature = "sidekiq")]
         Arc::new(SidekiqEnqueueHealthCheck {
-            context: context.clone(),
+            context: context.downgrade(),
         }),
         #[cfg(feature = "sidekiq")]
         Arc::new(SidekiqFetchHealthCheck {
-            context: context.clone(),
+            context: context.downgrade(),
         }),
         #[cfg(feature = "email-smtp")]
         Arc::new(SmtpHealthCheck {
-            context: context.clone(),
+            context: context.downgrade(),
         }),
     ];
 

--- a/src/health_check/email/smtp.rs
+++ b/src/health_check/email/smtp.rs
@@ -1,12 +1,12 @@
 use crate::api::core::health::smtp_health;
-use crate::app::context::AppContext;
+use crate::app::context::{AppContext, AppContextWeak};
 use crate::error::RoadsterResult;
-use crate::health_check::{CheckResponse, HealthCheck};
+use crate::health_check::{missing_context_response, CheckResponse, HealthCheck};
 use async_trait::async_trait;
 use tracing::instrument;
 
 pub struct SmtpHealthCheck {
-    pub(crate) context: AppContext,
+    pub(crate) context: AppContextWeak,
 }
 
 #[async_trait]
@@ -16,12 +16,20 @@ impl HealthCheck for SmtpHealthCheck {
     }
 
     fn enabled(&self) -> bool {
-        enabled(&self.context)
+        self.context
+            .upgrade()
+            .map(|context| enabled(&context))
+            .unwrap_or_default()
     }
 
     #[instrument(skip_all)]
     async fn check(&self) -> RoadsterResult<CheckResponse> {
-        Ok(smtp_health(&self.context, None).await)
+        let context = self.context.upgrade();
+        let response = match context {
+            Some(context) => smtp_health(&context, None).await,
+            None => missing_context_response(),
+        };
+        Ok(response)
     }
 }
 


### PR DESCRIPTION
This is useful for preventing reference cycles between things that are held in the `AppContext` and also need a reference to the `AppContext`; for example, `HealthCheck`s.

Closes https://github.com/roadster-rs/roadster/issues/526