### PR TITLE
feat: Add `AppWorker#enqueue_delayed`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
 #![deny(clippy::expect_used)]
 // Ignore the warning that the `coverage_nightly` cfg is not recognized.
 #![cfg_attr(test, allow(unexpected_cfgs))]
-// https://github.com/taiki-e/coverage-helper?tab=readme-ov-file#usage
-#![cfg_attr(all(test, coverage_nightly), feature(coverage_attribute))]
 
 pub mod api;
 pub mod app;

--- a/src/service/worker/sidekiq/app_worker.rs
+++ b/src/service/worker/sidekiq/app_worker.rs
@@ -65,6 +65,14 @@ where
         Ok(())
     }
 
+    /// Enqueue the worker into its Sidekiq queue. This is a helper method around [Worker::perform_in]
+    /// so the caller can simply provide the app state instead of needing to access the
+    /// [sidekiq::RedisPool] from inside the app state.
+    async fn enqueue_delayed(state: &S, delay: Duration, args: Args) -> RoadsterResult<()> {
+        Self::perform_in(AppContext::from_ref(state).redis_enqueue(), delay, args).await?;
+        Ok(())
+    }
+
     /// Provide the [AppWorkerConfig] for [Self]. The default implementation populates the
     /// [AppWorkerConfig] using the values from the corresponding methods on [Self], e.g.,
     /// [Self::max_retries].


### PR DESCRIPTION
Allow enqueuing delayed sidekiq jobs via the `AppWorker` trait.