### PR TITLE
feat: Add cache-related middlewares

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ axum-core = { workspace = true }
 axum = { workspace = true, features = ["macros"], optional = true }
 axum-extra = { workspace = true, features = ["typed-header", "cookie"], optional = true }
 tower = { workspace = true, optional = true }
-tower-http = { workspace = true, features = ["trace", "timeout", "request-id", "util", "normalize-path", "sensitive-headers", "catch-panic", "compression-full", "decompression-full", "limit", "cors"], optional = true }
+tower-http = { workspace = true, features = ["trace", "timeout", "request-id", "util", "normalize-path", "sensitive-headers", "catch-panic", "compression-full", "decompression-full", "limit", "cors", "set-header"], optional = true }
 aide = { workspace = true, features = ["axum", "redoc", "scalar", "macros"], optional = true }
 schemars = { workspace = true, optional = true }
 http-body-util = { version = "0.1.2", optional = true }

--- a/src/config/service/http/config/default.toml
+++ b/src/config/service/http/config/default.toml
@@ -30,6 +30,15 @@ priority = 0
 [service.http.middleware.response-compression]
 priority = 0
 
+[service.http.middleware.cache-control]
+priority = 0
+max-age = 86400
+
+[service.http.middleware.cache-control.content-types]
+
+[service.http.middleware.etag]
+priority = 0
+
 [service.http.middleware.request-decompression]
 priority = -9960
 

--- a/src/config/service/http/middleware.rs
+++ b/src/config/service/http/middleware.rs
@@ -1,10 +1,12 @@
 use crate::app::context::AppContext;
 use crate::config::CustomConfig;
+use crate::service::http::middleware::cache_control::CacheControlConfig;
 use crate::service::http::middleware::catch_panic::CatchPanicConfig;
 use crate::service::http::middleware::compression::{
     RequestDecompressionConfig, ResponseCompressionConfig,
 };
 use crate::service::http::middleware::cors::CorsConfig;
+use crate::service::http::middleware::etag::EtagConfig;
 use crate::service::http::middleware::request_id::{PropagateRequestIdConfig, SetRequestIdConfig};
 use crate::service::http::middleware::sensitive_headers::{
     SensitiveRequestHeadersConfig, SensitiveResponseHeadersConfig,
@@ -52,6 +54,10 @@ pub struct Middleware {
     pub cors: MiddlewareConfig<CorsConfig>,
 
     pub request_response_logging: MiddlewareConfig<RequestResponseLoggingConfig>,
+
+    pub cache_control: MiddlewareConfig<CacheControlConfig>,
+
+    pub etag: MiddlewareConfig<EtagConfig>,
 
     /// Allows providing configs for custom middleware. Any configs that aren't pre-defined above
     /// will be collected here.

--- a/src/config/snapshots/roadster__config__tests__test.snap
+++ b/src/config/snapshots/roadster__config__tests__test.snap
@@ -1,6 +1,7 @@
 ---
 source: src/config/mod.rs
 expression: config
+snapshot_kind: text
 ---
 environment = 'test'
 
@@ -97,6 +98,15 @@ max-age = 3600000
 [service.http.middleware.request-response-logging]
 priority = 0
 max-len = 1000
+
+[service.http.middleware.cache-control]
+priority = 0
+max-age = 86400
+
+[service.http.middleware.cache-control.content-types]
+
+[service.http.middleware.etag]
+priority = 0
 
 [service.http.initializer]
 default-enable = true

--- a/src/service/http/middleware/cache_control.rs
+++ b/src/service/http/middleware/cache_control.rs
@@ -1,0 +1,174 @@
+use crate::app::context::AppContext;
+use crate::error::RoadsterResult;
+use crate::service::http::middleware::Middleware;
+use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE};
+use axum::http::{HeaderValue, Response};
+use axum::Router;
+use axum_core::body::Body;
+use axum_core::extract::FromRef;
+use serde_derive::{Deserialize, Serialize};
+use serde_with::serde_as;
+use std::collections::BTreeMap;
+use std::time::Duration;
+use tower_http::set_header::SetResponseHeaderLayer;
+use validator::Validate;
+
+#[serde_as]
+#[derive(Debug, Clone, Default, Validate, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+#[non_exhaustive]
+pub struct CacheControlConfig {
+    /// The `max-age` to set in the `cache-control` header. The header will only be set
+    /// for responses who's content type matches an entry in the `content_types` field.
+    #[serde_as(as = "serde_with::DurationSeconds")]
+    pub max_age: Duration,
+
+    /// The content types to set the `cache-control` header for and any custom configuration for
+    /// each content type.
+    #[serde(default)]
+    pub content_types: BTreeMap<String, ContentTypeConfig>,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Default, Validate, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+#[non_exhaustive]
+pub struct ContentTypeConfig {
+    /// The `max-age` to set in the `cache-control` header for this content type. If not provided,
+    /// the `max-age` from [`CacheControlConfig`] will be used.
+    #[serde_as(as = "Option<serde_with::DurationSeconds>")]
+    pub max_age: Option<Duration>,
+}
+
+pub struct CacheControlMiddleware;
+impl<S> Middleware<S> for CacheControlMiddleware
+where
+    S: Clone + Send + Sync + 'static,
+    AppContext: FromRef<S>,
+{
+    fn name(&self) -> String {
+        "cache-control".to_string()
+    }
+
+    fn enabled(&self, state: &S) -> bool {
+        let context = AppContext::from_ref(state);
+        let config = &context
+            .config()
+            .service
+            .http
+            .custom
+            .middleware
+            .cache_control;
+
+        config.common.enabled(state) && !config.custom.content_types.is_empty()
+    }
+
+    fn priority(&self, state: &S) -> i32 {
+        AppContext::from_ref(state)
+            .config()
+            .service
+            .http
+            .custom
+            .middleware
+            .cache_control
+            .common
+            .priority
+    }
+
+    fn install(&self, router: Router, state: &S) -> RoadsterResult<Router> {
+        let state = state.clone();
+        let layer = SetResponseHeaderLayer::if_not_present(
+            CACHE_CONTROL,
+            move |response: &Response<Body>| {
+                let context = AppContext::from_ref(&state);
+                let config = &context
+                    .config()
+                    .service
+                    .http
+                    .custom
+                    .middleware
+                    .cache_control;
+                let max_age = config.custom.max_age;
+
+                let headers = response.headers();
+                headers
+                    .get(CONTENT_TYPE)
+                    .and_then(|content_type| content_type.to_str().ok())
+                    .and_then(|content_type| config.custom.content_types.get(content_type))
+                    .map(|config| config.max_age.unwrap_or(max_age))
+                    .and_then(|max_age| {
+                        HeaderValue::from_str(&format!("max-age={}", max_age.as_secs())).ok()
+                    })
+            },
+        );
+
+        let router = router.layer(layer);
+
+        Ok(router)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AppConfig;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(false, Some(true), None, false)]
+    #[case(false, Some(false), None, false)]
+    #[case(true, None, Some("text/css"), true)]
+    #[case(false, Some(true), Some("text/css"), true)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn enabled(
+        #[case] default_enable: bool,
+        #[case] enable: Option<bool>,
+        #[case] content_type: Option<&str>,
+        #[case] expected_enabled: bool,
+    ) {
+        // Arrange
+        let mut config = AppConfig::test(None).unwrap();
+        config.service.http.custom.middleware.default_enable = default_enable;
+        let cache_control_config = &mut config.service.http.custom.middleware.cache_control;
+        if let Some(content_type) = content_type {
+            cache_control_config
+                .custom
+                .content_types
+                .insert(content_type.to_string(), Default::default());
+        }
+        cache_control_config.common.enable = enable;
+
+        let context = AppContext::test(Some(config), None, None).unwrap();
+
+        let middleware = CacheControlMiddleware;
+
+        // Act/Assert
+        assert_eq!(middleware.enabled(&context), expected_enabled);
+    }
+
+    #[rstest]
+    #[case(None, 0)]
+    #[case(Some(1234), 1234)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn priority(#[case] override_priority: Option<i32>, #[case] expected_priority: i32) {
+        // Arrange
+        let mut config = AppConfig::test(None).unwrap();
+        if let Some(priority) = override_priority {
+            config
+                .service
+                .http
+                .custom
+                .middleware
+                .cache_control
+                .common
+                .priority = priority;
+        }
+
+        let context = AppContext::test(Some(config), None, None).unwrap();
+
+        let middleware = CacheControlMiddleware;
+
+        // Act/Assert
+        assert_eq!(middleware.priority(&context), expected_priority);
+    }
+}

--- a/src/service/http/middleware/default.rs
+++ b/src/service/http/middleware/default.rs
@@ -1,7 +1,9 @@
 use crate::app::context::AppContext;
+use crate::service::http::middleware::cache_control::CacheControlMiddleware;
 use crate::service::http::middleware::catch_panic::CatchPanicMiddleware;
 use crate::service::http::middleware::compression::RequestDecompressionMiddleware;
 use crate::service::http::middleware::cors::CorsMiddleware;
+use crate::service::http::middleware::etag::EtagMiddleware;
 use crate::service::http::middleware::request_id::{
     PropagateRequestIdMiddleware, SetRequestIdMiddleware,
 };
@@ -33,6 +35,8 @@ where
         Box::new(RequestBodyLimitMiddleware),
         Box::new(CorsMiddleware),
         Box::new(RequestResponseLoggingMiddleware),
+        Box::new(CacheControlMiddleware),
+        Box::new(EtagMiddleware),
     ];
 
     middleware
@@ -65,6 +69,16 @@ mod tests {
         // Arrange
         let mut config = AppConfig::test(None).unwrap();
         config.service.http.custom.middleware.default_enable = default_enable;
+
+        config
+            .service
+            .http
+            .custom
+            .middleware
+            .cache_control
+            .custom
+            .content_types
+            .insert("text/css".to_string(), Default::default());
 
         let context = AppContext::test(Some(config), None, None).unwrap();
 

--- a/src/service/http/middleware/etag.rs
+++ b/src/service/http/middleware/etag.rs
@@ -1,0 +1,131 @@
+use crate::app::context::AppContext;
+use crate::error::RoadsterResult;
+use crate::service::http::middleware::Middleware;
+use axum::extract::{FromRef, Request};
+use axum::http::header::ETAG;
+use axum::http::{HeaderMap, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::{middleware, Router};
+use serde_derive::{Deserialize, Serialize};
+use validator::Validate;
+
+#[derive(Debug, Clone, Default, Validate, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+#[non_exhaustive]
+pub struct EtagConfig {}
+
+pub struct EtagMiddleware;
+impl<S> Middleware<S> for EtagMiddleware
+where
+    S: Clone + Send + Sync + 'static,
+    AppContext: FromRef<S>,
+{
+    fn name(&self) -> String {
+        "etag".to_string()
+    }
+
+    fn enabled(&self, state: &S) -> bool {
+        AppContext::from_ref(state)
+            .config()
+            .service
+            .http
+            .custom
+            .middleware
+            .etag
+            .common
+            .enabled(state)
+    }
+
+    fn priority(&self, state: &S) -> i32 {
+        AppContext::from_ref(state)
+            .config()
+            .service
+            .http
+            .custom
+            .middleware
+            .etag
+            .common
+            .priority
+    }
+
+    fn install(&self, router: Router, _state: &S) -> RoadsterResult<Router> {
+        let router = router.layer(middleware::from_fn(etag_middleware));
+
+        Ok(router)
+    }
+}
+
+async fn etag_middleware(request: Request, next: Next) -> Response {
+    let request_headers = request.headers();
+    let request_etag = etag_value_from_headers(request_headers).map(|etag| etag.to_string());
+
+    let response = next.run(request).await;
+
+    if request_etag.is_none() {
+        return response;
+    }
+
+    let response_headers = response.headers();
+    let response_etag = etag_value_from_headers(response_headers);
+
+    if let Some((request_etag, response_etag)) = request_etag.zip(response_etag) {
+        if request_etag == response_etag {
+            return StatusCode::NOT_MODIFIED.into_response();
+        }
+    }
+
+    response
+}
+
+fn etag_value_from_headers(headers: &HeaderMap) -> Option<&str> {
+    headers.get(ETAG).and_then(|etag| etag.to_str().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AppConfig;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(false, Some(true), true)]
+    #[case(false, Some(false), false)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn enabled(
+        #[case] default_enable: bool,
+        #[case] enable: Option<bool>,
+        #[case] expected_enabled: bool,
+    ) {
+        // Arrange
+        let mut config = AppConfig::test(None).unwrap();
+        config.service.http.custom.middleware.default_enable = default_enable;
+        config.service.http.custom.middleware.etag.common.enable = enable;
+
+        let context = AppContext::test(Some(config), None, None).unwrap();
+
+        let middleware = EtagMiddleware;
+
+        // Act/Assert
+        assert_eq!(middleware.enabled(&context), expected_enabled);
+    }
+
+    #[rstest]
+    #[case(None, 0)]
+    #[case(Some(1234), 1234)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn priority(#[case] override_priority: Option<i32>, #[case] expected_priority: i32) {
+        // Arrange
+        let mut config = AppConfig::test(None).unwrap();
+        if let Some(priority) = override_priority {
+            config.service.http.custom.middleware.etag.common.priority = priority;
+        }
+
+        let context = AppContext::test(Some(config), None, None).unwrap();
+
+        let middleware = EtagMiddleware;
+
+        // Act/Assert
+        assert_eq!(middleware.priority(&context), expected_priority);
+    }
+}

--- a/src/service/http/middleware/mod.rs
+++ b/src/service/http/middleware/mod.rs
@@ -1,8 +1,10 @@
 pub mod any;
+pub mod cache_control;
 pub mod catch_panic;
 pub mod compression;
 pub mod cors;
 pub mod default;
+pub mod etag;
 pub mod request_id;
 pub mod sensitive_headers;
 pub mod size_limit;

--- a/src/service/http/middleware/snapshots/roadster__service__http__middleware__default__tests__default_middleware@case_2.snap
+++ b/src/service/http/middleware/snapshots/roadster__service__http__middleware__default__tests__default_middleware@case_2.snap
@@ -1,10 +1,13 @@
 ---
 source: src/service/http/middleware/default.rs
 expression: middleware
+snapshot_kind: text
 ---
 [
+    'cache-control',
     'catch-panic',
     'cors',
+    'etag',
     'propagate-request-id',
     'request-body-size-limit',
     'request-decompression',


### PR DESCRIPTION
Add two middlewares related to browser caching:

- CacheControlMiddleware: Sets the `cache-control` header for configured content types
- EtagMiddleware: Handles an `etag` header in request/response headers. If the header value is the same in the req and res, then a 304 is returned with an empty body.

Closes https://github.com/roadster-rs/roadster/issues/538