### PR TITLE
fix: Propagate `Validate` calls to all app config fields

### DIFF
--- a/src/config/database/mod.rs
+++ b/src/config/database/mod.rs
@@ -47,6 +47,7 @@ pub struct Database {
     /// building the app's [`crate::app::context::AppContext`].
     #[cfg(feature = "test-containers")]
     #[serde(default)]
+    #[validate(nested)]
     pub test_container: Option<crate::config::TestContainer>,
 }
 

--- a/src/config/health_check/mod.rs
+++ b/src/config/health_check/mod.rs
@@ -1,5 +1,5 @@
 use crate::app::context::AppContext;
-use crate::config::CustomConfig;
+use crate::config::{CustomConfig, EmptyConfig};
 use crate::util::serde::default_true;
 use axum_core::extract::FromRef;
 use config::{FileFormat, FileSourceString};
@@ -20,19 +20,20 @@ pub struct HealthCheck {
     #[serde(default = "default_true")]
     pub default_enable: bool,
 
+    #[validate(nested)]
     pub max_duration: MaxDuration,
 
     #[cfg(feature = "db-sql")]
     #[validate(nested)]
-    pub database: HealthCheckConfig<()>,
+    pub database: HealthCheckConfig<EmptyConfig>,
 
     #[cfg(feature = "sidekiq")]
     #[validate(nested)]
-    pub sidekiq: HealthCheckConfig<()>,
+    pub sidekiq: HealthCheckConfig<EmptyConfig>,
 
     #[cfg(feature = "email-smtp")]
     #[validate(nested)]
-    pub smtp: HealthCheckConfig<()>,
+    pub smtp: HealthCheckConfig<EmptyConfig>,
 
     /// Allows providing configs for custom health checks. Any configs that aren't pre-defined above
     /// will be collected here.
@@ -60,6 +61,7 @@ pub struct HealthCheck {
     /// }
     /// ```
     #[serde(flatten)]
+    #[validate(nested)]
     pub custom: BTreeMap<String, HealthCheckConfig<CustomConfig>>,
 }
 
@@ -93,10 +95,12 @@ impl CommonConfig {
 #[derive(Debug, Clone, Validate, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
-pub struct HealthCheckConfig<T> {
+pub struct HealthCheckConfig<T: Validate> {
     #[serde(flatten)]
+    #[validate(nested)]
     pub common: CommonConfig,
     #[serde(flatten)]
+    #[validate(nested)]
     pub custom: T,
 }
 

--- a/src/config/health_check/mod.rs
+++ b/src/config/health_check/mod.rs
@@ -1,5 +1,5 @@
 use crate::app::context::AppContext;
-use crate::config::{CustomConfig, EmptyConfig};
+use crate::config::CustomConfig;
 use crate::util::serde::default_true;
 use axum_core::extract::FromRef;
 use config::{FileFormat, FileSourceString};
@@ -25,15 +25,15 @@ pub struct HealthCheck {
 
     #[cfg(feature = "db-sql")]
     #[validate(nested)]
-    pub database: HealthCheckConfig<EmptyConfig>,
+    pub database: HealthCheckConfig<crate::config::EmptyConfig>,
 
     #[cfg(feature = "sidekiq")]
     #[validate(nested)]
-    pub sidekiq: HealthCheckConfig<EmptyConfig>,
+    pub sidekiq: HealthCheckConfig<crate::config::EmptyConfig>,
 
     #[cfg(feature = "email-smtp")]
     #[validate(nested)]
-    pub smtp: HealthCheckConfig<EmptyConfig>,
+    pub smtp: HealthCheckConfig<crate::config::EmptyConfig>,
 
     /// Allows providing configs for custom health checks. Any configs that aren't pre-defined above
     /// will be collected here.

--- a/src/config/lifecycle/mod.rs
+++ b/src/config/lifecycle/mod.rs
@@ -1,5 +1,5 @@
 use crate::app::context::AppContext;
-use crate::config::{CustomConfig, EmptyConfig};
+use crate::config::CustomConfig;
 use crate::util::serde::default_true;
 use config::{FileFormat, FileSourceString};
 use serde_derive::{Deserialize, Serialize};
@@ -19,7 +19,7 @@ pub struct LifecycleHandler {
 
     #[cfg(feature = "db-sql")]
     #[validate(nested)]
-    pub db_migration: LifecycleHandlerConfig<EmptyConfig>,
+    pub db_migration: LifecycleHandlerConfig<crate::config::EmptyConfig>,
 
     /// Allows providing configs for custom lifecycle handlers. Any configs that aren't pre-defined
     /// above will be collected here.

--- a/src/config/lifecycle/mod.rs
+++ b/src/config/lifecycle/mod.rs
@@ -1,5 +1,5 @@
 use crate::app::context::AppContext;
-use crate::config::CustomConfig;
+use crate::config::{CustomConfig, EmptyConfig};
 use crate::util::serde::default_true;
 use config::{FileFormat, FileSourceString};
 use serde_derive::{Deserialize, Serialize};
@@ -19,7 +19,7 @@ pub struct LifecycleHandler {
 
     #[cfg(feature = "db-sql")]
     #[validate(nested)]
-    pub db_migration: LifecycleHandlerConfig<()>,
+    pub db_migration: LifecycleHandlerConfig<EmptyConfig>,
 
     /// Allows providing configs for custom lifecycle handlers. Any configs that aren't pre-defined
     /// above will be collected here.
@@ -47,10 +47,11 @@ pub struct LifecycleHandler {
     /// }
     /// ```
     #[serde(flatten)]
+    #[validate(nested)]
     pub custom: BTreeMap<String, LifecycleHandlerConfig<CustomConfig>>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Validate)]
 #[serde(rename_all = "kebab-case", default)]
 #[non_exhaustive]
 pub struct CommonConfig {
@@ -72,10 +73,12 @@ impl CommonConfig {
 #[derive(Debug, Clone, Validate, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
-pub struct LifecycleHandlerConfig<T> {
+pub struct LifecycleHandlerConfig<T: Validate> {
     #[serde(flatten, default)]
+    #[validate(nested)]
     pub common: CommonConfig,
     #[serde(flatten)]
+    #[validate(nested)]
     pub custom: T,
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -97,9 +97,9 @@ impl Deref for CustomConfig {
     }
 }
 
-impl Into<BTreeMap<String, Value>> for CustomConfig {
-    fn into(self) -> BTreeMap<String, Value> {
-        self.inner
+impl From<CustomConfig> for BTreeMap<String, Value> {
+    fn from(value: CustomConfig) -> Self {
+        value.inner
     }
 }
 

--- a/src/config/service/http/default_routes.rs
+++ b/src/config/service/http/default_routes.rs
@@ -13,17 +13,22 @@ pub struct DefaultRoutes {
     #[serde(default = "default_true")]
     pub default_enable: bool,
 
+    #[validate(nested)]
     pub ping: DefaultRouteConfig,
 
+    #[validate(nested)]
     pub health: DefaultRouteConfig,
 
     #[cfg(feature = "open-api")]
+    #[validate(nested)]
     pub api_schema: DefaultRouteConfig,
 
     #[cfg(feature = "open-api")]
+    #[validate(nested)]
     pub scalar: DefaultRouteConfig,
 
     #[cfg(feature = "open-api")]
+    #[validate(nested)]
     pub redoc: DefaultRouteConfig,
 }
 
@@ -53,7 +58,7 @@ fn validate_default_routes(
     Ok(())
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct DefaultRouteConfig {

--- a/src/config/service/http/initializer.rs
+++ b/src/config/service/http/initializer.rs
@@ -17,7 +17,9 @@ pub struct Initializer {
     #[serde(default = "default_true")]
     pub default_enable: bool,
 
+    #[validate(nested)]
     pub normalize_path: InitializerConfig<NormalizePathConfig>,
+
     /// Allows providing configs for custom initializers. Any configs that aren't pre-defined above
     /// will be collected here.
     ///
@@ -45,10 +47,11 @@ pub struct Initializer {
     /// }
     /// ```
     #[serde(flatten)]
+    #[validate(nested)]
     pub custom: BTreeMap<String, InitializerConfig<CustomConfig>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct CommonConfig {
@@ -79,12 +82,14 @@ impl CommonConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
-pub struct InitializerConfig<T> {
+pub struct InitializerConfig<T: Validate> {
     #[serde(flatten)]
+    #[validate(nested)]
     pub common: CommonConfig,
     #[serde(flatten)]
+    #[validate(nested)]
     pub custom: T,
 }

--- a/src/config/service/http/middleware.rs
+++ b/src/config/service/http/middleware.rs
@@ -31,32 +31,46 @@ pub struct Middleware {
     #[serde(default = "default_true")]
     pub default_enable: bool,
 
+    #[validate(nested)]
     pub sensitive_request_headers: MiddlewareConfig<SensitiveRequestHeadersConfig>,
 
+    #[validate(nested)]
     pub sensitive_response_headers: MiddlewareConfig<SensitiveResponseHeadersConfig>,
 
+    #[validate(nested)]
     pub set_request_id: MiddlewareConfig<SetRequestIdConfig>,
 
+    #[validate(nested)]
     pub propagate_request_id: MiddlewareConfig<PropagateRequestIdConfig>,
 
+    #[validate(nested)]
     pub tracing: MiddlewareConfig<TracingConfig>,
 
+    #[validate(nested)]
     pub catch_panic: MiddlewareConfig<CatchPanicConfig>,
 
+    #[validate(nested)]
     pub response_compression: MiddlewareConfig<ResponseCompressionConfig>,
 
+    #[validate(nested)]
     pub request_decompression: MiddlewareConfig<RequestDecompressionConfig>,
 
+    #[validate(nested)]
     pub timeout: MiddlewareConfig<TimeoutConfig>,
 
+    #[validate(nested)]
     pub size_limit: MiddlewareConfig<SizeLimitConfig>,
 
+    #[validate(nested)]
     pub cors: MiddlewareConfig<CorsConfig>,
 
+    #[validate(nested)]
     pub request_response_logging: MiddlewareConfig<RequestResponseLoggingConfig>,
 
+    #[validate(nested)]
     pub cache_control: MiddlewareConfig<CacheControlConfig>,
 
+    #[validate(nested)]
     pub etag: MiddlewareConfig<EtagConfig>,
 
     /// Allows providing configs for custom middleware. Any configs that aren't pre-defined above
@@ -86,10 +100,11 @@ pub struct Middleware {
     /// }
     /// ```
     #[serde(flatten)]
+    #[validate(nested)]
     pub custom: BTreeMap<String, MiddlewareConfig<CustomConfig>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct CommonConfig {
@@ -124,10 +139,12 @@ impl CommonConfig {
 #[derive(Debug, Clone, Validate, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
-pub struct MiddlewareConfig<T> {
+pub struct MiddlewareConfig<T: Validate> {
     #[serde(flatten)]
+    #[validate(nested)]
     pub common: CommonConfig,
     #[serde(flatten)]
+    #[validate(nested)]
     pub custom: T,
 }
 

--- a/src/config/service/mod.rs
+++ b/src/config/service/mod.rs
@@ -12,8 +12,10 @@ use crate::config::service::grpc::GrpcServiceConfig;
 use crate::config::service::http::HttpServiceConfig;
 #[cfg(feature = "sidekiq")]
 use crate::config::service::worker::sidekiq::SidekiqServiceConfig;
+use crate::config::CustomConfig;
 use crate::util::serde::default_true;
 use serde_derive::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use validator::Validate;
 
 #[derive(Debug, Clone, Validate, Serialize, Deserialize)]
@@ -34,9 +36,13 @@ pub struct Service {
     #[cfg(feature = "sidekiq")]
     #[validate(nested)]
     pub sidekiq: ServiceConfig<SidekiqServiceConfig>,
+
+    #[serde(flatten)]
+    #[validate(nested)]
+    pub custom: BTreeMap<String, ServiceConfig<CustomConfig>>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Validate)]
 #[serde(rename_all = "kebab-case", default)]
 #[non_exhaustive]
 pub struct CommonConfig {
@@ -59,6 +65,7 @@ impl CommonConfig {
 #[non_exhaustive]
 pub struct ServiceConfig<T: Validate> {
     #[serde(flatten, default)]
+    #[validate(nested)]
     pub common: CommonConfig,
     #[serde(flatten)]
     #[validate(nested)]

--- a/src/service/http/initializer/normalize_path.rs
+++ b/src/service/http/initializer/normalize_path.rs
@@ -6,8 +6,9 @@ use axum_core::extract::FromRef;
 use serde_derive::{Deserialize, Serialize};
 use tower::Layer;
 use tower_http::normalize_path::NormalizePathLayer;
+use validator::Validate;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Validate)]
 #[serde(rename_all = "kebab-case", default)]
 #[non_exhaustive]
 pub struct NormalizePathConfig {}

--- a/src/service/http/middleware/cache_control.rs
+++ b/src/service/http/middleware/cache_control.rs
@@ -26,6 +26,7 @@ pub struct CacheControlConfig {
     /// The content types to set the `cache-control` header for and any custom configuration for
     /// each content type.
     #[serde(default)]
+    #[validate(nested)]
     pub content_types: BTreeMap<String, ContentTypeConfig>,
 }
 

--- a/src/service/http/middleware/request_id.rs
+++ b/src/service/http/middleware/request_id.rs
@@ -31,6 +31,7 @@ impl Default for CommonRequestIdConfig {
 #[non_exhaustive]
 pub struct SetRequestIdConfig {
     #[serde(flatten)]
+    #[validate(nested)]
     pub common: CommonRequestIdConfig,
 }
 
@@ -39,6 +40,7 @@ pub struct SetRequestIdConfig {
 #[non_exhaustive]
 pub struct PropagateRequestIdConfig {
     #[serde(flatten)]
+    #[validate(nested)]
     pub common: CommonRequestIdConfig,
 }
 

--- a/src/service/http/middleware/sensitive_headers.rs
+++ b/src/service/http/middleware/sensitive_headers.rs
@@ -49,6 +49,7 @@ impl CommonSensitiveHeadersConfig {
 #[non_exhaustive]
 pub struct SensitiveRequestHeadersConfig {
     #[serde(flatten)]
+    #[validate(nested)]
     pub common: CommonSensitiveHeadersConfig,
 }
 
@@ -57,6 +58,7 @@ pub struct SensitiveRequestHeadersConfig {
 #[non_exhaustive]
 pub struct SensitiveResponseHeadersConfig {
     #[serde(flatten)]
+    #[validate(nested)]
     pub common: CommonSensitiveHeadersConfig,
 }
 


### PR DESCRIPTION
Custom configs will need to be validated separately by the consumer after they deserialize the embedded `Value` into a specific type.

Closes https://github.com/roadster-rs/roadster/issues/358