### PR TITLE
chore: Update `config` to 0.15.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ config-yml = ["config/yaml"]
 # Config
 # We only support `toml` configs currently, and one of the default features (`rust-ini`) pulls in a dependency
 # that breaks the coverage build on nightly.
-config = { version = "0.14.1", default-features = false, features = ["toml", "convert-case"] }
+config = { version = "0.15.6", default-features = false, features = ["toml", "convert-case"] }
 dotenvy = "0.15.5"
 
 # Tracing


### PR DESCRIPTION
`0.15.5` had a regression that was fixed in `0.15.6` (in [this PR](https://github.com/rust-cli/config-rs/pull/627)), so we need at least that version

Closes https://github.com/roadster-rs/roadster/issues/534