### PR TITLE
feat!: Return `RedisEnqueue` and `RedisFetch` redis pool "new-types"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ bb8 = { workspace = true, optional = true }
 num_cpus = { workspace = true, optional = true }
 
 # Rust async
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 async-trait = { workspace = true }
 
@@ -185,7 +185,7 @@ tonic-build = { version = "0.12.3" }
 tonic-reflection = { version = "0.12.0" }
 
 # Sidekiq
-# Todo: the default `rss-stats` feature has a dependency that currently can't be satisfied (memchr: ~2.3)
+# The default `rss-stats` feature has a dependency that currently can't be satisfied on macos (memchr: ~2.3)
 rusty-sidekiq = { version = "0.13.1", default-features = false }
 bb8 = { version = "0.9.0" }
 num_cpus = { version = "1.13.0" }
@@ -197,8 +197,7 @@ testcontainers-modules = { version = "0.11.3" }
 mockall = "0.13.0"
 
 # Others
-# Todo: minimize tokio features included in `roadster`
-tokio = { version = "1.39.0", features = ["full"] }
+tokio = { version = "1.39.0" }
 # For CancellationToken
 tokio-util = { version = "0.7.10" }
 anyhow = "1.0.86"

--- a/src/api/core/health.rs
+++ b/src/api/core/health.rs
@@ -1,4 +1,4 @@
-use crate::app::context::{AppContext, RedisEnqueue};
+use crate::app::context::AppContext;
 use crate::error::RoadsterResult;
 use crate::health_check::{CheckResponse, ErrorData, HealthCheck, Status};
 #[cfg(feature = "open-api")]

--- a/src/api/core/health.rs
+++ b/src/api/core/health.rs
@@ -1,4 +1,4 @@
-use crate::app::context::AppContext;
+use crate::app::context::{AppContext, RedisEnqueue};
 use crate::error::RoadsterResult;
 use crate::health_check::{CheckResponse, ErrorData, HealthCheck, Status};
 #[cfg(feature = "open-api")]

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -470,7 +470,6 @@ struct AppContextInner {
     /// The Redis connection pool used by [sidekiq::Processor] to fetch Sidekiq jobs from Redis.
     /// May be `None` if the [fetch_pool.max_connections][crate::config::service::worker::sidekiq::ConnectionPool]
     /// config is set to zero, in which case the [sidekiq::Processor] would also not be started.
-    // todo: In the next breaking version, wrap the pool in the `RedisFetch` new-type
     #[cfg(feature = "sidekiq")]
     redis_fetch: Option<RedisFetch>,
     #[cfg(all(feature = "sidekiq", feature = "test-containers"))]

--- a/src/service/worker/sidekiq/builder.rs
+++ b/src/service/worker/sidekiq/builder.rs
@@ -141,7 +141,7 @@ where
                         processor_config.queue_config(queue.clone(), config.into())
                     });
 
-                let processor = sidekiq::Processor::new(redis_fetch.clone(), queues.clone())
+                let processor = sidekiq::Processor::new(redis_fetch.inner.clone(), queues.clone())
                     .with_config(processor_config);
                 ProcessorWrapper::new(processor)
             };
@@ -188,7 +188,7 @@ where
             // Periodic jobs are not removed automatically. Remove any periodic jobs that were
             // previously added. They should be re-added by `App::worker`.
             info!("Auto-cleaning periodic jobs");
-            periodic::destroy_all(context.redis_enqueue().clone()).await?;
+            periodic::destroy_all(context.redis_enqueue().inner.clone()).await?;
         }
 
         Ok(())
@@ -212,7 +212,7 @@ where
                 return Err(anyhow!("Can only clean up previous periodic jobs if no periodic jobs have been registered yet.").into());
             }
             let context = AppContext::from_ref(context);
-            periodic::destroy_all(context.redis_enqueue().clone()).await?;
+            periodic::destroy_all(context.redis_enqueue().inner.clone()).await?;
         }
 
         Ok(self)


### PR DESCRIPTION
To help prevent using the wrong redis pool to enqueue vs fetch, return the connection pools wrapped in "new-type" structs.