### PR TITLE
docs: Add `ExampleHealthCheck` to the `full` example

### DIFF
--- a/examples/full/config/default.toml
+++ b/examples/full/config/default.toml
@@ -15,3 +15,6 @@ priority = 5
 [service.grpc]
 host = "127.0.0.1"
 port = 3001
+
+[health-check.example]
+enable = true

--- a/examples/full/src/app_state.rs
+++ b/examples/full/src/app_state.rs
@@ -1,10 +1,48 @@
 use axum::extract::FromRef;
 use roadster::app::context::AppContext;
 use roadster::app::context::{Provide, ProvideRef};
+use roadster::config::environment::Environment;
+use std::ops::Deref;
+use std::sync::{Arc, Weak};
 
-#[derive(Clone, FromRef)]
+#[derive(Clone)]
+#[non_exhaustive]
 pub struct AppState {
+    inner: Arc<Inner>,
+}
+
+impl Deref for AppState {
+    type Target = Inner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// A version of [`AppState`] that holds a [`Weak`] pointer to the [`Inner`] state. Useful for
+/// preventing reference cycles between things that are held in the [`AppState`] and also
+/// need a reference to the [`AppState`]; for example, [`roadster::health_check::HealthCheck`]s.
+#[derive(Clone)]
+pub struct AppStateWeak {
+    inner: Weak<Inner>,
+}
+
+impl AppStateWeak {
+    /// Get an [`AppState`] from [`Self`].
+    pub fn upgrade(&self) -> Option<AppState> {
+        self.inner.upgrade().map(|inner| AppState { inner })
+    }
+}
+
+#[non_exhaustive]
+pub struct Inner {
     pub app_context: AppContext,
+}
+
+impl FromRef<AppState> for AppContext {
+    fn from_ref(input: &AppState) -> Self {
+        input.app_context.clone()
+    }
 }
 
 impl<T> Provide<T> for AppState
@@ -22,5 +60,24 @@ where
 {
     fn provide(&self) -> &T {
         ProvideRef::provide(&self.app_context)
+    }
+}
+
+impl AppState {
+    pub fn new(app_context: AppContext) -> Self {
+        Self {
+            inner: Arc::new(Inner { app_context }),
+        }
+    }
+
+    pub fn is_prod(&self) -> bool {
+        self.app_context.config().environment == Environment::Production
+    }
+
+    /// Get an [`AppStateWeak`] from [`Self`].
+    pub fn downgrade(&self) -> AppStateWeak {
+        AppStateWeak {
+            inner: Arc::downgrade(&self.inner),
+        }
     }
 }

--- a/examples/full/src/health/example.rs
+++ b/examples/full/src/health/example.rs
@@ -1,0 +1,76 @@
+use crate::app_state::{AppState, AppStateWeak};
+use async_trait::async_trait;
+use roadster::error::RoadsterResult;
+use roadster::health_check::{CheckResponse, ErrorData, HealthCheck, Status};
+use std::time::Duration;
+use tracing::error;
+
+/// An example [`HealthCheck`] implementation demonstrating how to use [`AppStateWeak`] in order
+/// to prevent a reference cycle.
+///
+/// The [`roadster::app::context::AppContext`] contained in the regular [`AppState`] contains
+/// the list of registered [`HealthCheck`]s. This causes a reference cycle unless we use a weak
+/// pointer to break the cycle. Note that in a production system, this reference cycle is not likely
+/// to cause any actual issues because the [`roadster::app::context::AppContext`] and the
+/// [`HealthCheck`]s should all live for the lifetime of your application process anyway. However,
+/// it can cause issues if you're using Roadster's `test-containers` feature -- the test containers
+/// are only cleaned up when the [`roadster::app::context::AppContext`] is dropped, but a reference
+/// cycle can cause the [`roadster::app::context::AppContext`] to never be dropped, so the
+/// test containers would never be cleaned up. This may not be an immediate issue, but it
+/// could cause your local development environment to become clogged with a bunch of unnecessary
+/// docker containers.
+pub struct ExampleHealthCheck {
+    state: AppStateWeak,
+}
+
+impl ExampleHealthCheck {
+    pub fn new(state: &AppState) -> Self {
+        Self {
+            state: state.downgrade(),
+        }
+    }
+}
+
+#[async_trait]
+impl HealthCheck for ExampleHealthCheck {
+    fn name(&self) -> String {
+        "example".to_string()
+    }
+
+    fn enabled(&self) -> bool {
+        let state = match self.state.upgrade() {
+            Some(state) => state,
+            None => return false,
+        };
+        state
+            .app_context
+            .config()
+            .health_check
+            .custom
+            .get(&self.name())
+            .map(|config| config.common.enabled(&state))
+            .unwrap_or(state.app_context.config().health_check.default_enable)
+    }
+
+    async fn check(&self) -> RoadsterResult<CheckResponse> {
+        let state = self.state.upgrade();
+
+        let response = match state {
+            Some(_state) => CheckResponse::builder()
+                .status(Status::Ok)
+                .latency(Duration::from_millis(0))
+                .custom("Example health check successful")
+                .build(),
+            None => {
+                let msg = "AppState missing; is the app shutting down?".to_string();
+                error!(msg);
+                CheckResponse::builder()
+                    .status(Status::Err(ErrorData::builder().msg(msg).build()))
+                    .latency(Duration::from_secs(0))
+                    .build()
+            }
+        };
+
+        Ok(response)
+    }
+}

--- a/examples/full/src/health/mod.rs
+++ b/examples/full/src/health/mod.rs
@@ -1,0 +1,1 @@
+pub mod example;

--- a/examples/full/src/lib.rs
+++ b/examples/full/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod app;
 pub mod app_state;
 pub mod cli;
+pub mod health;
 pub mod model;
 pub mod service;
 pub mod worker;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -552,6 +552,7 @@ where
     /// This method is intentionally not provided in the builder-style API of [`RoadsterApp`]; it's
     /// expected that consumers would provide their shutdown logic in a
     /// [`crate::lifecycle::AppLifecycleHandler::on_shutdown`] implementation instead.
+    // todo: remove in favor of [`crate::lifecycle::AppLifecycleHandler`]s
     #[instrument(skip_all)]
     async fn graceful_shutdown(self: Arc<Self>, _state: &S) -> RoadsterResult<()> {
         Ok(())

--- a/src/health_check/mod.rs
+++ b/src/health_check/mod.rs
@@ -95,13 +95,10 @@ pub trait HealthCheck: Send + Sync {
 // This method is not used in all feature configurations.
 #[allow(dead_code)]
 fn missing_context_response() -> CheckResponse {
-    error!("AppContext missing");
+    let msg = "AppContext missing; is the app shutting down?".to_string();
+    error!(msg);
     CheckResponse::builder()
-        .status(Status::Err(
-            ErrorData::builder()
-                .msg("Unknown error".to_string())
-                .build(),
-        ))
+        .status(Status::Err(ErrorData::builder().msg(msg).build()))
         .latency(Duration::from_secs(0))
         .build()
 }


### PR DESCRIPTION
Uses a weak pointer version of the `AppState` to demonstrate how to use the weak pointer to break the reference cycle between heath checks and the `AppContext`.

Closes https://github.com/roadster-rs/roadster/issues/574