### PR TITLE
chore!: Remove the `App#graceful_shutdown` method

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -50,7 +50,7 @@ use sea_orm_migration::MigratorTrait;
 use std::env;
 use std::future;
 use std::sync::Arc;
-use tracing::{error, info, instrument, warn};
+use tracing::{error, info, warn};
 
 pub async fn run<A, S>(app: A) -> RoadsterResult<()>
 where
@@ -503,10 +503,10 @@ where
     }
 
     /// Provide the app state that will be used throughout the app. The state can simply be the
-    /// provided [AppContext], or a custom type that implements [FromRef] to allow Roadster to
-    /// extract its [AppContext] when needed.
+    /// provided [`AppContext`], or a custom type that implements [`FromRef`] to allow Roadster to
+    /// extract its [`AppContext`] when needed.
     ///
-    /// See the following for more details regarding [FromRef]: <https://docs.rs/axum/0.7.5/axum/extract/trait.FromRef.html>
+    /// See the following for more details regarding [`FromRef`]: <https://docs.rs/axum/0.7.5/axum/extract/trait.FromRef.html>
     async fn provide_state(&self, context: AppContext) -> RoadsterResult<S>;
 
     async fn lifecycle_handlers(
@@ -540,22 +540,6 @@ where
     /// server when a particular API is called.
     async fn graceful_shutdown_signal(self: Arc<Self>, _state: &S) {
         let _output: () = future::pending().await;
-    }
-
-    /// Override to provide custom graceful shutdown logic to clean up any resources created by
-    /// the app. Roadster will take care of cleaning up the resources it created.
-    ///
-    /// Alternatively, provide a [`crate::lifecycle::AppLifecycleHandler::on_shutdown`]
-    /// implementation and provide the handler to the [`LifecycleHandlerRegistry`] in
-    /// [`Self::lifecycle_handlers`].
-    ///
-    /// This method is intentionally not provided in the builder-style API of [`RoadsterApp`]; it's
-    /// expected that consumers would provide their shutdown logic in a
-    /// [`crate::lifecycle::AppLifecycleHandler::on_shutdown`] implementation instead.
-    // todo: remove in favor of [`crate::lifecycle::AppLifecycleHandler`]s
-    #[instrument(skip_all)]
-    async fn graceful_shutdown(self: Arc<Self>, _state: &S) -> RoadsterResult<()> {
-        Ok(())
     }
 }
 

--- a/src/config/lifecycle/default.toml
+++ b/src/config/lifecycle/default.toml
@@ -1,2 +1,5 @@
 [lifecycle-handler.db-migration]
 priority = 0
+
+[lifecycle-handler.db-graceful-shutdown]
+priority = 10000

--- a/src/config/lifecycle/mod.rs
+++ b/src/config/lifecycle/mod.rs
@@ -21,6 +21,10 @@ pub struct LifecycleHandler {
     #[validate(nested)]
     pub db_migration: LifecycleHandlerConfig<crate::config::EmptyConfig>,
 
+    #[cfg(feature = "db-sql")]
+    #[validate(nested)]
+    pub db_graceful_shutdown: LifecycleHandlerConfig<crate::config::EmptyConfig>,
+
     /// Allows providing configs for custom lifecycle handlers. Any configs that aren't pre-defined
     /// above will be collected here.
     ///

--- a/src/config/snapshots/roadster__config__tests__test.snap
+++ b/src/config/snapshots/roadster__config__tests__test.snap
@@ -14,6 +14,9 @@ default-enable = true
 [lifecycle-handler.db-migration]
 priority = 0
 
+[lifecycle-handler.db-graceful-shutdown]
+priority = 10000
+
 [health-check]
 default-enable = true
 

--- a/src/lifecycle/db/graceful_shutdown.rs
+++ b/src/lifecycle/db/graceful_shutdown.rs
@@ -98,7 +98,11 @@ mod tests {
         // Arrange
         let mut config = AppConfig::test(None).unwrap();
         if let Some(priority) = override_priority {
-            config.lifecycle_handler.db_migration.common.priority = priority;
+            config
+                .lifecycle_handler
+                .db_graceful_shutdown
+                .common
+                .priority = priority;
         }
 
         let context = AppContext::test(Some(config), None, None).unwrap();

--- a/src/lifecycle/db/graceful_shutdown.rs
+++ b/src/lifecycle/db/graceful_shutdown.rs
@@ -91,7 +91,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case(None, 0)]
+    #[case(None, 10000)]
     #[case(Some(1234), 1234)]
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn priority(#[case] override_priority: Option<i32>, #[case] expected_priority: i32) {

--- a/src/lifecycle/db/graceful_shutdown.rs
+++ b/src/lifecycle/db/graceful_shutdown.rs
@@ -1,5 +1,4 @@
-//! This [`AppLifecycleHandler`] runs the app's ['up' migration][`MigratorTrait::up`]
-//! in [`AppLifecycleHandler::before_services`].
+//! This [`AppLifecycleHandler`] closes the DB connection pool when the app is shutting down.
 
 use crate::app::context::AppContext;
 use crate::app::App;
@@ -7,30 +6,29 @@ use crate::error::RoadsterResult;
 use crate::lifecycle::AppLifecycleHandler;
 use async_trait::async_trait;
 use axum_core::extract::FromRef;
-use sea_orm_migration::MigratorTrait;
+use tracing::instrument;
 
-pub struct DbMigrationLifecycleHandler;
+pub struct DbGracefulShutdownLifecycleHandler;
 
 #[async_trait]
-impl<A, S> AppLifecycleHandler<A, S> for DbMigrationLifecycleHandler
+impl<A, S> AppLifecycleHandler<A, S> for DbGracefulShutdownLifecycleHandler
 where
     S: Clone + Send + Sync + 'static,
     AppContext: FromRef<S>,
     A: App<S> + 'static,
 {
     fn name(&self) -> String {
-        "db-migration".to_string()
+        "db-graceful-shutdown".to_string()
     }
 
     fn enabled(&self, state: &S) -> bool {
         let context = AppContext::from_ref(state);
-        context.config().database.auto_migrate
-            && context
-                .config()
-                .lifecycle_handler
-                .db_migration
-                .common
-                .enabled(&context)
+        context
+            .config()
+            .lifecycle_handler
+            .db_graceful_shutdown
+            .common
+            .enabled(&context)
     }
 
     fn priority(&self, state: &S) -> i32 {
@@ -38,15 +36,23 @@ where
         context
             .config()
             .lifecycle_handler
-            .db_migration
+            .db_graceful_shutdown
             .common
             .priority
     }
 
-    async fn before_services(&self, state: &S) -> RoadsterResult<()> {
-        let context = AppContext::from_ref(state);
-
-        A::M::up(context.db(), None).await?;
+    #[instrument(skip_all)]
+    async fn on_shutdown(&self, #[allow(unused_variables)] state: &S) -> RoadsterResult<()> {
+        #[cfg(not(feature = "testing-mocks"))]
+        {
+            tracing::info!("Closing the DB connection pool.");
+            let context = AppContext::from_ref(state);
+            context.db().clone().close().await?;
+        }
+        #[cfg(feature = "testing-mocks")]
+        {
+            tracing::warn!("Unable to manually close the db connection pool when `testing-mocks` feature is enabled.");
+        }
 
         Ok(())
     }
@@ -71,11 +77,11 @@ mod tests {
         // Arrange
         let mut config = AppConfig::test(None).unwrap();
         config.lifecycle_handler.default_enable = default_enable;
-        config.lifecycle_handler.db_migration.common.enable = enable;
+        config.lifecycle_handler.db_graceful_shutdown.common.enable = enable;
 
         let context = AppContext::test(Some(config), None, None).unwrap();
 
-        let handler = DbMigrationLifecycleHandler;
+        let handler = DbGracefulShutdownLifecycleHandler;
 
         // Act/Assert
         assert_eq!(
@@ -97,7 +103,7 @@ mod tests {
 
         let context = AppContext::test(Some(config), None, None).unwrap();
 
-        let handler = DbMigrationLifecycleHandler;
+        let handler = DbGracefulShutdownLifecycleHandler;
 
         // Act/Assert
         assert_eq!(

--- a/src/lifecycle/db/migration.rs
+++ b/src/lifecycle/db/migration.rs
@@ -1,0 +1,110 @@
+//! This [`AppLifecycleHandler`] runs the app's ['up' migration][`MigratorTrait::up`]
+//! in [`AppLifecycleHandler::before_services`].
+
+use crate::app::context::AppContext;
+use crate::app::App;
+use crate::error::RoadsterResult;
+use crate::lifecycle::AppLifecycleHandler;
+use async_trait::async_trait;
+use axum_core::extract::FromRef;
+use sea_orm_migration::MigratorTrait;
+use tracing::instrument;
+
+pub struct DbMigrationLifecycleHandler;
+
+#[async_trait]
+impl<A, S> AppLifecycleHandler<A, S> for DbMigrationLifecycleHandler
+where
+    S: Clone + Send + Sync + 'static,
+    AppContext: FromRef<S>,
+    A: App<S> + 'static,
+{
+    fn name(&self) -> String {
+        "db-migration".to_string()
+    }
+
+    fn enabled(&self, state: &S) -> bool {
+        let context = AppContext::from_ref(state);
+        context.config().database.auto_migrate
+            && context
+                .config()
+                .lifecycle_handler
+                .db_migration
+                .common
+                .enabled(&context)
+    }
+
+    fn priority(&self, state: &S) -> i32 {
+        let context = AppContext::from_ref(state);
+        context
+            .config()
+            .lifecycle_handler
+            .db_migration
+            .common
+            .priority
+    }
+
+    #[instrument(skip_all)]
+    async fn before_services(&self, state: &S) -> RoadsterResult<()> {
+        let context = AppContext::from_ref(state);
+
+        A::M::up(context.db(), None).await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::MockApp;
+    use crate::config::AppConfig;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(false, Some(true), true)]
+    #[case(false, Some(false), false)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn enabled(
+        #[case] default_enable: bool,
+        #[case] enable: Option<bool>,
+        #[case] expected_enabled: bool,
+    ) {
+        // Arrange
+        let mut config = AppConfig::test(None).unwrap();
+        config.lifecycle_handler.default_enable = default_enable;
+        config.lifecycle_handler.db_migration.common.enable = enable;
+
+        let context = AppContext::test(Some(config), None, None).unwrap();
+
+        let handler = DbMigrationLifecycleHandler;
+
+        // Act/Assert
+        assert_eq!(
+            AppLifecycleHandler::<MockApp<AppContext>, AppContext>::enabled(&handler, &context),
+            expected_enabled
+        );
+    }
+
+    #[rstest]
+    #[case(None, 0)]
+    #[case(Some(1234), 1234)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    fn priority(#[case] override_priority: Option<i32>, #[case] expected_priority: i32) {
+        // Arrange
+        let mut config = AppConfig::test(None).unwrap();
+        if let Some(priority) = override_priority {
+            config.lifecycle_handler.db_migration.common.priority = priority;
+        }
+
+        let context = AppContext::test(Some(config), None, None).unwrap();
+
+        let handler = DbMigrationLifecycleHandler;
+
+        // Act/Assert
+        assert_eq!(
+            AppLifecycleHandler::<MockApp<AppContext>, AppContext>::priority(&handler, &context),
+            expected_priority
+        );
+    }
+}

--- a/src/lifecycle/db/mod.rs
+++ b/src/lifecycle/db/mod.rs
@@ -1,0 +1,2 @@
+pub mod graceful_shutdown;
+pub mod migration;

--- a/src/lifecycle/default.rs
+++ b/src/lifecycle/default.rs
@@ -14,7 +14,9 @@ where
 {
     let lifecycle_handlers: Vec<Box<dyn AppLifecycleHandler<A, S>>> = vec![
         #[cfg(feature = "db-sql")]
-        Box::new(crate::lifecycle::db_migration::DbMigrationLifecycleHandler),
+        Box::new(crate::lifecycle::db::migration::DbMigrationLifecycleHandler),
+        #[cfg(feature = "db-sql")]
+        Box::new(crate::lifecycle::db::graceful_shutdown::DbGracefulShutdownLifecycleHandler),
     ];
 
     lifecycle_handlers

--- a/src/lifecycle/mod.rs
+++ b/src/lifecycle/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "db-sql")]
-pub mod db_migration;
+pub mod db;
 pub mod default;
 pub mod registry;
 


### PR DESCRIPTION
Removed in favor of the `AppLifecycleHandler` hooks.