### PR TITLE
chore: Refactor `RoadsterApp` to reduce duplication

### DIFF
--- a/examples/app-builder/src/lib.rs
+++ b/examples/app-builder/src/lib.rs
@@ -16,10 +16,10 @@ cfg_if! {
 if #[cfg(all(feature = "cli", feature = "db-sql"))] {
     pub type App = RoadsterApp<AppState, cli::AppCli, migration::Migrator>;
 } else if #[cfg(feature = "cli")] {
-    pub type App = RoadsterApp<AppState, crate::cli::AppCli>;
+    pub type App = RoadsterApp<AppState, crate::cli::AppCli, roadster::util::empty::Empty>;
 } else if #[cfg(feature = "db-sql")] {
-    pub type App = RoadsterApp<AppState, migration::Migrator>;
+    pub type App = RoadsterApp<AppState, roadster::util::empty::Empty, migration::Migrator>;
 } else {
-    pub type App = RoadsterApp<AppState>;
+    pub type App = RoadsterApp<AppState, roadster::util::empty::Empty, roadster::util::empty::Empty>;
 }
 }

--- a/examples/app-builder/src/main.rs
+++ b/examples/app-builder/src/main.rs
@@ -4,8 +4,9 @@ use app_builder::health::check::example::ExampleHealthCheck;
 use app_builder::lifecycle::example::ExampleLifecycleHandler;
 use app_builder::worker::example::ExampleWorker;
 use app_builder::App;
+use roadster::app;
 use roadster::app::metadata::AppMetadata;
-use roadster::app::RoadsterApp;
+use roadster::app::{RoadsterApp, RoadsterAppBuilder};
 use roadster::error::RoadsterResult;
 use roadster::service::function::service::FunctionService;
 use roadster::service::http::service::HttpService;
@@ -19,7 +20,7 @@ const BASE: &str = "/api";
 async fn main() -> RoadsterResult<()> {
     let custom_state = "custom".to_string();
 
-    let builder = RoadsterApp::builder()
+    let builder: RoadsterAppBuilder<AppState, _, _> = RoadsterApp::builder()
         .tracing_initializer(|config| roadster::tracing::init_tracing(config, &metadata()));
 
     // Metadata can either be provided directly or via a provider callback. Note that the two
@@ -95,7 +96,7 @@ async fn main() -> RoadsterResult<()> {
                     .register_builder(
                         SidekiqWorkerService::builder(state)
                             .await?
-                            .register_worker(ExampleWorker::default())?,
+                            .register_worker(ExampleWorker)?,
                     )
                     .await?;
                 Ok(())
@@ -110,7 +111,9 @@ async fn main() -> RoadsterResult<()> {
 
     let app: App = builder.build();
 
-    app.run().await
+    app::run(app).await?;
+
+    Ok(())
 }
 
 fn metadata() -> AppMetadata {

--- a/src/util/empty.rs
+++ b/src/util/empty.rs
@@ -1,0 +1,53 @@
+/// A placeholder that implements various traits so it can be used as the default for various type
+/// parameters
+pub struct Empty;
+
+#[cfg(feature = "cli")]
+#[async_trait::async_trait]
+impl<
+        S,
+        #[cfg(feature = "db-sql")] M: 'static + sea_orm_migration::MigratorTrait + Send + Sync,
+        #[cfg(not(feature = "db-sql"))] M: 'static + Send + Sync,
+    > crate::api::cli::RunCommand<crate::app::RoadsterApp<S, Empty, M>, S> for Empty
+where
+    S: Clone + Send + Sync + 'static,
+    crate::app::context::AppContext: axum_core::extract::FromRef<S>,
+{
+    async fn run(
+        &self,
+        _app: &crate::app::RoadsterApp<S, Empty, M>,
+        _cli: &Empty,
+        _state: &S,
+    ) -> crate::error::RoadsterResult<bool> {
+        Ok(false)
+    }
+}
+
+#[cfg(feature = "cli")]
+impl clap::Args for Empty {
+    fn augment_args(cmd: clap::Command) -> clap::Command {
+        cmd
+    }
+
+    fn augment_args_for_update(cmd: clap::Command) -> clap::Command {
+        cmd
+    }
+}
+
+#[cfg(feature = "cli")]
+impl clap::FromArgMatches for Empty {
+    fn from_arg_matches(_matches: &clap::ArgMatches) -> Result<Self, clap::Error> {
+        Ok(Empty)
+    }
+
+    fn update_from_arg_matches(&mut self, _matches: &clap::ArgMatches) -> Result<(), clap::Error> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "db-sql")]
+impl sea_orm_migration::MigratorTrait for Empty {
+    fn migrations() -> Vec<Box<dyn sea_orm_migration::MigrationTrait>> {
+        Default::default()
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
+pub mod empty;
 #[cfg(feature = "sidekiq")]
 pub(crate) mod redis;
 pub mod regex;


### PR DESCRIPTION
Use conditional compilation of type parameters of `RoadsterApp` to enable/disable the bounds on the type parameters depending on which features are enabled. This allows us to have a single implementation of `RoadsterApp` instead of having multiple implementations that are conditionally compiled using `cfg_if`, greatly reducing code duplication and our maintenance burden.

A downside of this approach is RustRover seems to not play super well with the conditionally compiled type parameters. It seems to sometimes ignore the conditional compilation, leading to it thinking that there are 5 type parameters even though two sets of them are mutually exclusive and can't be enabled at the same time so there should only ever be 3 type parameters. However, things compile and we can write our code in a certain way that RustRover seems to like. See the `app-builder` example for an example.

Also, add an `Empty` type that can be used as a placeholder/default for various type parameters.

Closes https://github.com/roadster-rs/roadster/issues/546