### PR TITLE
feat!: Add `db-sea-orm` feature to prepare for other DB crate support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,12 @@ rust-version = "1.81"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["sidekiq", "db-sql", "open-api", "jwt-ietf", "cli", "otel"]
+default = ["sidekiq", "db-sea-orm", "open-api", "jwt-ietf", "cli", "otel"]
 http = ["dep:axum", "dep:axum-extra", "dep:tower", "dep:tower-http", "dep:http-body-util", "dep:mime"]
 open-api = ["http", "dep:aide", "dep:schemars"]
 sidekiq = ["dep:rusty-sidekiq", "dep:bb8", "dep:num_cpus"]
-db-sql = ["dep:sea-orm", "dep:sea-orm-migration"]
+db-sql = []
+db-sea-orm = ["dep:sea-orm", "dep:sea-orm-migration", "db-sql"]
 email = ["dep:lettre"]
 email-smtp = ["email"]
 email-sendgrid = ["email", "dep:sendgrid"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ and [Poem](https://github.com/poem-web/poem).
 - Provides sample JWT extractor for Axum (requires the `jwt-ietf` and/or `jwt-openid` features). Also provides a general
   JWT extractor for Axum that simply puts all claims into a map (available with the `jwt` feature)
 - Built-in support for [SeaORM](https://crates.io/crates/sea-orm), including creating DB connections (requires
-  the `db-sql` feature)
+  the `db-sea-orm` feature)
 - Built-in support for [Sidekiq.rs](https://crates.io/crates/rusty-sidekiq) for running async/background jobs (requires
   the `sidekiq` feature)
 - Built-in support for sending emails via SMTP (requires the `email-smtp` feature)
@@ -45,9 +45,9 @@ and [Poem](https://github.com/poem-web/poem).
 - Structured logs/traces using tokio's [tracing](https://docs.rs/tracing/latest/tracing/) crate. Export traces/metrics
   using OpenTelemetry (requires the `otel` feature).
 - Health checks to ensure the app's external dependencies are healthy
-- Pre-built migrations for common DB tables, e.g. `user` (requires the `db-sql` feature)
+- Pre-built migrations for common DB tables, e.g. `user` (requires the `db-sea-orm` feature)
 - Support for auto-updating timestamp columns, e.g. `updated_at`, when updating DB rows (Postgres only currently) (
-  requires the `db-sql` feature)
+  requires the `db-sea-orm` feature)
 
 # Getting started
 

--- a/book/src/features/database/index.md
+++ b/book/src/features/database/index.md
@@ -1,6 +1,6 @@
 # Database
 
-When the `db-sql` feature is enabled, Roadster provides support for various SQL databases
+When the `db-sea-orm` feature is enabled, Roadster provides support for various SQL databases
 via [SeaORM](https://docs.rs/sea-orm/1.1.4/sea_orm/), an ORM built on top of [sqlx](https://docs.rs/sqlx/latest/sqlx/).
 See the SeaORM docs for more details.
 

--- a/examples/app-builder/Cargo.toml
+++ b/examples/app-builder/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["cli", "db-sql"]
+default = ["cli", "db-sea-orm"]
 cli = ["roadster/cli", "clap"]
-db-sql = ["roadster/db-sql", "app-builder-migration", "sea-orm"]
+db-sea-orm = ["roadster/db-sea-orm", "app-builder-migration", "sea-orm"]
 
 [dependencies]
 roadster = { version = "0.7.0-alpha.3", path = "../..", default-features = false, features = ["open-api", "sidekiq"] }

--- a/examples/app-builder/migration/Cargo.toml
+++ b/examples/app-builder/migration/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 
 [dependencies]
 tokio = { workspace = true }
-roadster = { path = "../../..", default-features = false, features = ["db-sql"] }
+roadster = { path = "../../..", default-features = false, features = ["db-sea-orm"] }
 
 [dependencies.sea-orm-migration]
 workspace = true

--- a/examples/app-builder/src/lib.rs
+++ b/examples/app-builder/src/lib.rs
@@ -8,16 +8,16 @@ pub mod app_state;
 pub mod cli;
 pub mod health;
 pub mod lifecycle;
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 pub mod model;
 pub mod worker;
 
 cfg_if! {
-if #[cfg(all(feature = "cli", feature = "db-sql"))] {
+if #[cfg(all(feature = "cli", feature = "db-sea-orm"))] {
     pub type App = RoadsterApp<AppState, cli::AppCli, migration::Migrator>;
 } else if #[cfg(feature = "cli")] {
     pub type App = RoadsterApp<AppState, crate::cli::AppCli, roadster::util::empty::Empty>;
-} else if #[cfg(feature = "db-sql")] {
+} else if #[cfg(feature = "db-sea-orm")] {
     pub type App = RoadsterApp<AppState, roadster::util::empty::Empty, migration::Migrator>;
 } else {
     pub type App = RoadsterApp<AppState, roadster::util::empty::Empty, roadster::util::empty::Empty>;

--- a/examples/app-builder/src/main.rs
+++ b/examples/app-builder/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> RoadsterResult<()> {
 
     // Db connection options can either be provided directly or via a provider callback. Note that
     // the two approaches are mutually exclusive, with the `db_conn_options` method taking priority.
-    #[cfg(feature = "db-sql")]
+    #[cfg(feature = "db-sea-orm")]
     let builder = {
         let mut db_conn_options =
             sea_orm::ConnectOptions::new("postgres://roadster:roadster@localhost:5432/example_dev");

--- a/examples/full/migration/Cargo.toml
+++ b/examples/full/migration/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 
 [dependencies]
 tokio = { workspace = true }
-roadster = { path = "../../..", default-features = false, features = ["db-sql"] }
+roadster = { path = "../../..", default-features = false, features = ["db-sea-orm"] }
 
 [dependencies.sea-orm-migration]
 workspace = true

--- a/private/powerset_matrix/src/main.rs
+++ b/private/powerset_matrix/src/main.rs
@@ -33,6 +33,7 @@ fn main() -> anyhow::Result<()> {
         vec!["jwt", "jwt-ietf"],
         vec!["jwt", "jwt-openid"],
         vec!["open-api", "http"],
+        vec!["db-sea-orm", "db-sql"],
     ]
     .into_iter()
     .map(|v| v.into_iter().map(|s| s.to_string()).collect())

--- a/src/api/cli/mod.rs
+++ b/src/api/cli/mod.rs
@@ -199,7 +199,7 @@ mod tests {
     #[cfg_attr(feature = "open-api", case::list_routes(Some("roadster list-routes")))]
     #[cfg_attr(feature = "open-api", case::list_routes(Some("r list-routes")))]
     #[cfg_attr(feature = "open-api", case::open_api(Some("r open-api")))]
-    #[cfg_attr(feature = "db-sql", case::migrate(Some("r migrate up")))]
+    #[cfg_attr(feature = "db-sea-orm", case::migrate(Some("r migrate up")))]
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn parse_cli(_case: TestCase, #[case] args: Option<&str>) {
         // Arrange

--- a/src/api/cli/roadster/mod.rs
+++ b/src/api/cli/roadster/mod.rs
@@ -1,7 +1,7 @@
 use crate::api::cli::roadster::health::HealthArgs;
 #[cfg(feature = "open-api")]
 use crate::api::cli::roadster::list_routes::ListRoutesArgs;
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 use crate::api::cli::roadster::migrate::MigrateArgs;
 use crate::api::cli::roadster::print_config::PrintConfigArgs;
 use crate::app::context::AppContext;
@@ -20,7 +20,7 @@ use serde_derive::Serialize;
 pub mod health;
 #[cfg(feature = "open-api")]
 pub mod list_routes;
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 pub mod migrate;
 pub mod print_config;
 
@@ -154,7 +154,7 @@ where
                 /// Implemented by [crate::service::http::service::HttpService]
                 Ok(false)
             }
-            #[cfg(feature = "db-sql")]
+            #[cfg(feature = "db-sea-orm")]
             RoadsterSubCommand::Migrate(args) => args.run(app, cli, state).await,
             RoadsterSubCommand::PrintConfig(args) => args.run(app, cli, state).await,
             RoadsterSubCommand::Health(args) => args.run(app, cli, state).await,
@@ -179,7 +179,7 @@ pub enum RoadsterSubCommand {
     OpenApi(OpenApiArgs),
 
     /// Perform DB operations using SeaORM migrations.
-    #[cfg(feature = "db-sql")]
+    #[cfg(feature = "db-sea-orm")]
     #[clap(visible_aliases = ["m", "migration"])]
     Migrate(MigrateArgs),
 

--- a/src/api/cli/roadster/print_config.rs
+++ b/src/api/cli/roadster/print_config.rs
@@ -68,7 +68,7 @@ fn serialize_config(format: &Format, config: &AppConfig) -> RoadsterResult<Strin
     feature = "http",
     feature = "open-api",
     feature = "sidekiq",
-    feature = "db-sql",
+    feature = "db-sea-orm",
     feature = "email-smtp",
     feature = "email-sendgrid",
     feature = "jwt",

--- a/src/api/core/health.rs
+++ b/src/api/core/health.rs
@@ -9,7 +9,7 @@ use axum_core::extract::FromRef;
 use futures::future::join_all;
 #[cfg(feature = "open-api")]
 use schemars::JsonSchema;
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 use sea_orm::DatabaseConnection;
 use serde_derive::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
@@ -129,7 +129,7 @@ pub struct Latency {
     pub ping_latency: Option<u128>,
 }
 
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 pub(crate) async fn db_health(context: &AppContext, duration: Option<Duration>) -> CheckResponse {
     let db_timer = Instant::now();
     let db_status = match ping_db(context.db(), duration).await {
@@ -143,7 +143,7 @@ pub(crate) async fn db_health(context: &AppContext, duration: Option<Duration>) 
         .build()
 }
 
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 #[instrument(skip_all)]
 async fn ping_db(db: &DatabaseConnection, duration: Option<Duration>) -> RoadsterResult<()> {
     if let Some(duration) = duration {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,7 +7,7 @@ mod roadster_app;
 /// See <https://github.com/roadster-rs/roadster/tree/main/examples/app-builder/src/main.rs> for
 /// an example of how to use the [`RoadsterApp`].
 ///
-/// The `Cli` and `M` type parameters are only required when the `cli` and `db-sql` features are
+/// The `Cli` and `M` type parameters are only required when the `cli` and `db-sea-orm` features are
 /// enabled, respectively.
 pub use roadster_app::RoadsterApp;
 
@@ -16,7 +16,7 @@ pub use roadster_app::RoadsterApp;
 /// See <https://github.com/roadster-rs/roadster/tree/main/examples/app-builder/src/main.rs> for
 /// an example of how to use the [`RoadsterAppBuilder`].
 ///
-/// The `Cli` and `M` type parameters are only required when the `cli` and `db-sql` features are
+/// The `Cli` and `M` type parameters are only required when the `cli` and `db-sea-orm` features are
 /// enabled, respectively.
 pub use roadster_app::RoadsterAppBuilder;
 
@@ -39,11 +39,11 @@ use crate::tracing::init_tracing;
 use async_trait::async_trait;
 use axum_core::extract::FromRef;
 use context::AppContext;
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 use sea_orm::ConnectOptions;
-#[cfg(all(test, feature = "db-sql"))]
+#[cfg(all(test, feature = "db-sea-orm"))]
 use sea_orm_migration::MigrationTrait;
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 use sea_orm_migration::MigratorTrait;
 #[cfg(feature = "cli")]
 use std::env;
@@ -484,10 +484,10 @@ where
     Ok(())
 }
 
-#[cfg_attr(all(test, feature = "cli", feature = "db-sql"), mockall::automock(type Cli = MockTestCli<S>; type M = MockMigrator;))]
-#[cfg_attr(all(test, feature = "cli", not(feature = "db-sql")), mockall::automock(type Cli = MockTestCli<S>; type M = crate::util::empty::Empty;))]
-#[cfg_attr(all(test, not(feature = "cli"), feature = "db-sql"), mockall::automock(type Cli = crate::util::empty::Empty; type M = MockMigrator;))]
-#[cfg_attr(all(test, not(feature = "cli"), not(feature = "db-sql")), mockall::automock(type Cli = crate::util::empty::Empty; type M = crate::util::empty::Empty;))]
+#[cfg_attr(all(test, feature = "cli", feature = "db-sea-orm"), mockall::automock(type Cli = MockTestCli<S>; type M = MockMigrator;))]
+#[cfg_attr(all(test, feature = "cli", not(feature = "db-sea-orm")), mockall::automock(type Cli = MockTestCli<S>; type M = crate::util::empty::Empty;))]
+#[cfg_attr(all(test, not(feature = "cli"), feature = "db-sea-orm"), mockall::automock(type Cli = crate::util::empty::Empty; type M = MockMigrator;))]
+#[cfg_attr(all(test, not(feature = "cli"), not(feature = "db-sea-orm")), mockall::automock(type Cli = crate::util::empty::Empty; type M = crate::util::empty::Empty;))]
 #[async_trait]
 pub trait App<S>: Send + Sync
 where
@@ -498,9 +498,9 @@ where
     type Cli: clap::Args + RunCommand<Self, S> + Send + Sync;
     #[cfg(not(feature = "cli"))]
     type Cli;
-    #[cfg(feature = "db-sql")]
+    #[cfg(feature = "db-sea-orm")]
     type M: MigratorTrait;
-    #[cfg(not(feature = "db-sql"))]
+    #[cfg(not(feature = "db-sea-orm"))]
     type M;
 
     fn init_tracing(&self, config: &AppConfig) -> RoadsterResult<()> {
@@ -513,7 +513,7 @@ where
         Ok(Default::default())
     }
 
-    #[cfg(feature = "db-sql")]
+    #[cfg(feature = "db-sea-orm")]
     fn db_connection_options(&self, config: &AppConfig) -> RoadsterResult<ConnectOptions> {
         Ok(ConnectOptions::from(&config.database))
     }
@@ -559,7 +559,7 @@ where
     }
 }
 
-#[cfg(all(test, feature = "db-sql"))]
+#[cfg(all(test, feature = "db-sea-orm"))]
 mockall::mock! {
     pub Migrator {}
     #[async_trait]

--- a/src/config/health/check/mod.rs
+++ b/src/config/health/check/mod.rs
@@ -23,7 +23,7 @@ pub struct HealthCheck {
     #[validate(nested)]
     pub max_duration: MaxDuration,
 
-    #[cfg(feature = "db-sql")]
+    #[cfg(feature = "db-sea-orm")]
     #[validate(nested)]
     pub database: HealthCheckConfig<crate::config::EmptyConfig>,
 

--- a/src/config/lifecycle/mod.rs
+++ b/src/config/lifecycle/mod.rs
@@ -17,11 +17,11 @@ pub struct LifecycleHandler {
     #[serde(default = "default_true")]
     pub default_enable: bool,
 
-    #[cfg(feature = "db-sql")]
+    #[cfg(feature = "db-sea-orm")]
     #[validate(nested)]
     pub db_migration: LifecycleHandlerConfig<crate::config::EmptyConfig>,
 
-    #[cfg(feature = "db-sql")]
+    #[cfg(feature = "db-sea-orm")]
     #[validate(nested)]
     pub db_graceful_shutdown: LifecycleHandlerConfig<crate::config::EmptyConfig>,
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,5 @@
 use crate::config::auth::Auth;
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 use crate::config::database::Database;
 #[cfg(feature = "email")]
 use crate::config::email::Email;
@@ -26,7 +26,7 @@ use typed_builder::TypedBuilder;
 use validator::{Validate, ValidationErrors};
 
 pub mod auth;
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 pub mod database;
 #[cfg(feature = "email")]
 pub mod email;
@@ -53,7 +53,7 @@ pub struct AppConfig {
     pub auth: Auth,
     #[validate(nested)]
     pub tracing: Tracing,
-    #[cfg(feature = "db-sql")]
+    #[cfg(feature = "db-sea-orm")]
     #[validate(nested)]
     pub database: Database,
     #[cfg(feature = "email")]
@@ -373,7 +373,7 @@ pub struct TestContainer {
     feature = "http",
     feature = "open-api",
     feature = "sidekiq",
-    feature = "db-sql",
+    feature = "db-sea-orm",
     feature = "email-smtp",
     feature = "email-sendgrid",
     feature = "jwt",

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -59,7 +59,7 @@ pub enum Error {
     #[error(transparent)]
     Serde(#[from] SerdeError),
 
-    #[cfg(feature = "db-sql")]
+    #[cfg(feature = "db-sea-orm")]
     #[error(transparent)]
     Db(#[from] sea_orm::DbErr),
 

--- a/src/health/check/default.rs
+++ b/src/health/check/default.rs
@@ -1,5 +1,5 @@
 use crate::app::context::AppContext;
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 use crate::health::check::database::DatabaseHealthCheck;
 #[cfg(feature = "email-smtp")]
 use crate::health::check::email::smtp::SmtpHealthCheck;
@@ -15,7 +15,7 @@ pub fn default_health_checks(
     #[allow(unused_variables)] context: &AppContext,
 ) -> BTreeMap<String, Arc<dyn HealthCheck>> {
     let health_checks: Vec<Arc<dyn HealthCheck>> = vec![
-        #[cfg(feature = "db-sql")]
+        #[cfg(feature = "db-sea-orm")]
         Arc::new(DatabaseHealthCheck {
             context: context.downgrade(),
         }),
@@ -40,7 +40,12 @@ pub fn default_health_checks(
         .collect()
 }
 
-#[cfg(all(test, feature = "sidekiq", feature = "db-sql", feature = "email-smtp"))]
+#[cfg(all(
+    test,
+    feature = "sidekiq",
+    feature = "db-sea-orm",
+    feature = "email-smtp"
+))]
 mod tests {
     use crate::app::context::AppContext;
     use crate::config::AppConfig;

--- a/src/health/check/mod.rs
+++ b/src/health/check/mod.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 pub mod database;
 pub mod default;
 #[cfg(feature = "email")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod error;
 pub mod health;
 pub mod lifecycle;
 pub mod middleware;
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 pub mod migration;
 pub mod service;
 #[cfg(any(test, feature = "testing"))]

--- a/src/lifecycle/default.rs
+++ b/src/lifecycle/default.rs
@@ -13,9 +13,9 @@ where
     A: App<S> + 'static,
 {
     let lifecycle_handlers: Vec<Box<dyn AppLifecycleHandler<A, S>>> = vec![
-        #[cfg(feature = "db-sql")]
+        #[cfg(feature = "db-sea-orm")]
         Box::new(crate::lifecycle::db::migration::DbMigrationLifecycleHandler),
-        #[cfg(feature = "db-sql")]
+        #[cfg(feature = "db-sea-orm")]
         Box::new(crate::lifecycle::db::graceful_shutdown::DbGracefulShutdownLifecycleHandler),
     ];
 

--- a/src/lifecycle/mod.rs
+++ b/src/lifecycle/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 pub mod db;
 pub mod default;
 pub mod registry;

--- a/src/util/empty.rs
+++ b/src/util/empty.rs
@@ -10,8 +10,8 @@ pub struct Empty;
 #[async_trait::async_trait]
 impl<
         S,
-        #[cfg(feature = "db-sql")] M: 'static + sea_orm_migration::MigratorTrait + Send + Sync,
-        #[cfg(not(feature = "db-sql"))] M: 'static + Send + Sync,
+        #[cfg(feature = "db-sea-orm")] M: 'static + sea_orm_migration::MigratorTrait + Send + Sync,
+        #[cfg(not(feature = "db-sea-orm"))] M: 'static + Send + Sync,
     > crate::api::cli::RunCommand<crate::app::RoadsterApp<S, Empty, M>, S> for Empty
 where
     S: Clone + Send + Sync + 'static,
@@ -49,7 +49,7 @@ impl clap::FromArgMatches for Empty {
     }
 }
 
-#[cfg(feature = "db-sql")]
+#[cfg(feature = "db-sea-orm")]
 impl sea_orm_migration::MigratorTrait for Empty {
     fn migrations() -> Vec<Box<dyn sea_orm_migration::MigrationTrait>> {
         Default::default()


### PR DESCRIPTION
We'd like to add support for Diesel, so we should have a separate feature flag for sea-orm vs diesel. Add a `db-sea-orm` flag and replace all instances of `db-sql` with it. We'll keep the old `db-sql` feature as well for now in case there's any common code to use between both, for example, app config fields.