### PR TITLE
chore: Replace native-tls with rustls in several dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ sea-orm = { version = "1.1.2" }
 sea-orm-migration = { version = "1.1.2" }
 
 # Email
-lettre = "0.11.0"
+lettre = { version = "0.11.0", default-features = false, features = ["smtp-transport", "pool", "rustls-tls", "hostname", "builder"] }
 sendgrid = "0.23.0"
 
 # CLI
@@ -222,7 +222,7 @@ validator = { version = "0.20.0", features = ["derive"] }
 cfg-if = "1.0.0"
 vergen = { version = "9.0.0" }
 vergen-gitcl = { version = "1.0.0" }
-reqwest = "0.12.8"
+reqwest = { version = "0.12.8", default-features = false, features = ["rustls-tls", "charset", "http2", "macos-system-configuration"] }
 itertools = "0.14.0"
 cargo-manifest = "0.18.0"
 typed-builder = "0.20.0"


### PR DESCRIPTION
Currently `lettre` and `reqwest` use `native-tls` whilst several other dependencies have explicitly specified `rustls`. The nested system dependancy on `libssl` makes building and deploying on alpine very annoying (theoretically possible, but as yet no luck in my current project).

Given the mismatch and difficulties with `openssl`, it makes sense to me to consolidate on `rustls`