### PR TITLE
docs: Remove unnecessary `Empty` for `RoadsterApp` `Cli` type

### DIFF
--- a/book/examples/app-config/src/lib.rs
+++ b/book/examples/app-config/src/lib.rs
@@ -1,11 +1,10 @@
 use crate::example_async_source::ExampleAsyncSource;
 use roadster::app::context::AppContext;
 use roadster::app::RoadsterApp;
-use roadster::util::empty::Empty;
 
 pub mod example_async_source;
 
-pub type App = RoadsterApp<AppContext, Empty>;
+pub type App = RoadsterApp<AppContext>;
 
 pub fn build_app() -> App {
     let builder = RoadsterApp::builder();

--- a/book/examples/app-context/src/app.rs
+++ b/book/examples/app-context/src/app.rs
@@ -6,10 +6,9 @@ use roadster::app::context::{AppContext, AppContextWeak};
 use roadster::app::RoadsterApp;
 use roadster::error::RoadsterResult;
 use roadster::health::check::{CheckResponse, HealthCheck, Status};
-use roadster::util::empty::Empty;
 use std::time::Duration;
 
-pub type App = RoadsterApp<CustomState, Empty>;
+pub type App = RoadsterApp<CustomState>;
 
 pub struct ExampleHealthCheck {
     // Prevent reference cycle because the `ExampleHealthCheck` is also stored in the `AppContext`

--- a/book/examples/database/src/roadster_app.rs
+++ b/book/examples/database/src/roadster_app.rs
@@ -1,9 +1,8 @@
 use crate::migrator::Migrator;
 use roadster::app::context::AppContext;
 use roadster::app::RoadsterApp;
-use roadster::util::empty::Empty;
 
-type App = RoadsterApp<AppContext, Empty>;
+type App = RoadsterApp<AppContext>;
 
 fn build_app() -> App {
     RoadsterApp::builder()

--- a/book/examples/service/src/http/open_api.rs
+++ b/book/examples/service/src/http/open_api.rs
@@ -3,9 +3,8 @@ use roadster::app::{prepare, PrepareOptions, RoadsterApp};
 use roadster::error::RoadsterResult;
 use roadster::service::http::service::HttpService;
 use roadster::service::http::service::OpenApiArgs;
-use roadster::util::empty::Empty;
 
-type App = RoadsterApp<AppContext, Empty>;
+type App = RoadsterApp<AppContext>;
 
 async fn open_api() -> RoadsterResult<()> {
     // Build the app

--- a/book/examples/service/src/lib.rs
+++ b/book/examples/service/src/lib.rs
@@ -3,9 +3,8 @@ mod http;
 use roadster::app::context::AppContext;
 use roadster::app::RoadsterApp;
 use roadster::service::http::service::HttpService;
-use roadster::util::empty::Empty;
 
-type App = RoadsterApp<AppContext, Empty>;
+type App = RoadsterApp<AppContext>;
 
 fn build_app() -> App {
     RoadsterApp::builder()

--- a/examples/app-builder/src/lib.rs
+++ b/examples/app-builder/src/lib.rs
@@ -15,6 +15,6 @@ cfg_if! {
 if #[cfg(feature = "cli")] {
     pub type App = RoadsterApp<AppState, api::cli::AppCli>;
 } else {
-    pub type App = RoadsterApp<AppState, roadster::util::empty::Empty>;
+    pub type App = RoadsterApp<AppState>;
 }
 }

--- a/src/lifecycle/registry.rs
+++ b/src/lifecycle/registry.rs
@@ -23,11 +23,10 @@ use tracing::info;
 /// # use roadster::app::RoadsterApp;
 /// # use roadster::lifecycle::AppLifecycleHandler;
 /// # use roadster::lifecycle::registry::LifecycleHandlerRegistry;
-/// # use roadster::util::empty::Empty;
 /// #
 /// struct ExampleLifecycleHandler;
 ///
-/// type App = RoadsterApp<AppContext, Empty>;
+/// type App = RoadsterApp<AppContext>;
 ///
 /// impl AppLifecycleHandler<App, AppContext> for ExampleLifecycleHandler {
 ///     fn name(&self) -> String {

--- a/src/service/function/service.rs
+++ b/src/service/function/service.rs
@@ -20,7 +20,6 @@ use typed_builder::TypedBuilder;
 /// # use roadster::service::function::service::FunctionService;
 /// # use roadster::service::registry::ServiceRegistry;
 /// # use roadster::app::RoadsterApp;
-/// # use roadster::util::empty::Empty;
 ///
 /// async fn example_service(
 ///     _state: AppContext,
@@ -30,7 +29,7 @@ use typed_builder::TypedBuilder;
 /// #    unimplemented!()
 /// }
 ///
-/// type App = RoadsterApp<AppContext, Empty>;
+/// type App = RoadsterApp<AppContext>;
 ///
 /// let service = FunctionService::builder()
 ///             .name("example".to_string())

--- a/src/service/registry.rs
+++ b/src/service/registry.rs
@@ -123,7 +123,6 @@ where
 # tokio_test::block_on(async {
 # use roadster::service::http::service::OpenApiArgs;
 # use roadster::app::RoadsterApp;
-# use roadster::util::empty::Empty;
 # use roadster::service::AppServiceBuilder;
 # use roadster::service::http::service::HttpService;
 # use std::env::current_dir;
@@ -141,7 +140,7 @@ where
 # use roadster::app::prepare;
 # use roadster::service::AppService;
 #
-type App = RoadsterApp<AppContext, Empty>;
+type App = RoadsterApp<AppContext>;
 
 let app: App = RoadsterApp::builder()
     .state_provider(|state| Ok(state))


### PR DESCRIPTION
`Empty` is the default `Cli` type for the `RoadsterApp` if none is provided, so we don't need to specify it.

This partially addresses https://github.com/roadster-rs/roadster/issues/616, but I don't want to close that yet in case I can think of how to remove the associated type entirely.