### PR TITLE
fix!: Fix `run_test*` to skip CLI

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -38,3 +38,4 @@
     - [Testing](features/testing.md)
 - [Adding a UI](adding-a-ui/index.md)
     - [With Leptos](adding-a-ui/leptos.md)
+- [Changelog](changelog.md)

--- a/book/src/changelog.md
+++ b/book/src/changelog.md
@@ -1,0 +1,1 @@
+{{#include ../../CHANGELOG.md}}

--- a/book/src/comparisons/loco.md
+++ b/book/src/comparisons/loco.md
@@ -12,7 +12,7 @@ based on Axum and Tokio, there's not a lot technically preventing either framewo
 missing compared to the other. Features that Roadster would like to add in the near future are marked with '*'. Other
 missing features are not planned but we'd be open to adding if there was enough interest in them.
 
-*Last updated in Oct 2024.*
+*Last updated in Feb 2025.*
 
 | Feature                                                                                                                         | Roadster       | Loco                                      |
 |:--------------------------------------------------------------------------------------------------------------------------------|:---------------|:------------------------------------------|
@@ -65,6 +65,7 @@ missing features are not planned but we'd be open to adding if there was enough 
 | [insta](https://crates.io/crates/insta) snapshot utilities                                                                      | ✅              | ✅                                         |
 | Data seeding and cleanup hooks for tests                                                                                        | ❌*             | ✅<br/>(⚠️ makes tests non-parallelizable) |
 | Mock DB support for tests                                                                                                       | ✅              | ❌                                         |
+| &ensp;↳ via Temporary Test DBs                                                                                                  | ✅              | ✅                                         |
 | &ensp;↳ via SeaORM's [MockDatabase](https://www.sea-ql.org/SeaORM/docs/write-test/mock/)                                        | ✅              | ❌                                         |
 | &ensp;↳ via [TestContainers](https://testcontainers.com/)                                                                       | ✅              | ❌                                         |
 | Allows following any design pattern                                                                                             | ✅              | ❌<br/>(MVC only)                          |

--- a/examples/app-builder/config/test.toml
+++ b/examples/app-builder/config/test.toml
@@ -5,7 +5,7 @@ format = "pretty"
 secret = "secret-test"
 
 [database]
-uri = "postgres://roadster:roadster@localhost:5433/example_test"
+uri = "postgres://roadster:roadster@localhost:5432/example_dev"
 temporary-test-db = true
 
 [service.sidekiq]

--- a/src/app/snapshots/roadster__app__tests__prepare_options_test.snap
+++ b/src/app/snapshots/roadster__app__tests__prepare_options_test.snap
@@ -6,5 +6,6 @@ PrepareOptions {
     env: Some(
         Test,
     ),
+    parse_cli: false,
     config_dir: None,
 }


### PR DESCRIPTION
The `run_test*` functions were parsing the CLI, which results in the tests failing due to unexpected parameters.

Refactor some methods in `roadster::app` to allow skipping the CLI even if the feature flag is enabled. This (for now) requires making the cli fields optional in the prepared app. Maybe we can figure out a better solution in the future.