### PR TITLE
feat: Allow overriding config fields or entire config

### DIFF
--- a/src/app/snapshots/roadster__app__prepare__tests__prepare_options_test.snap
+++ b/src/app/snapshots/roadster__app__prepare__tests__prepare_options_test.snap
@@ -8,4 +8,6 @@ PrepareOptions {
     ),
     parse_cli: false,
     config_dir: None,
+    config_sources: [],
+    config: None,
 }


### PR DESCRIPTION
Add fields to `PrepareOptions` to allow providing custom config sources and/or overriding specific config fields. Also allow overriding the entire `AppConfig` if desired.