### PR TITLE
docs: Expand OpenAPI chapter

### DIFF
--- a/book/examples/app-config/Cargo.toml
+++ b/book/examples/app-config/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "app-config"
+name = "app-config-example"
 version = "0.1.0"
 edition = "2024"
 publish = false

--- a/book/examples/app-context/Cargo.toml
+++ b/book/examples/app-context/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "app-context"
+name = "app-context-example"
 version = "0.1.0"
 edition = "2024"
 publish = false

--- a/book/examples/auth/Cargo.toml
+++ b/book/examples/auth/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "auth-example"
+name = "auth-example-example"
 version = "0.1.0"
 edition = "2024"
 publish = false

--- a/book/examples/ch-02-getting-started/Cargo.toml
+++ b/book/examples/ch-02-getting-started/Cargo.toml
@@ -1,7 +1,0 @@
-[package]
-name = "ch-02-getting-started"
-version = "0.1.0"
-edition = "2024"
-publish = false
-
-[dependencies]

--- a/book/examples/ch-02-getting-started/src/main.rs
+++ b/book/examples/ch-02-getting-started/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Test of including a rust snippet in mdbook.");
-}

--- a/book/examples/database-diesel/Cargo.toml
+++ b/book/examples/database-diesel/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "database-diesel"
+name = "database-diesel-example"
 version = "0.1.0"
 edition = "2024"
 publish = false

--- a/book/examples/database/Cargo.toml
+++ b/book/examples/database/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "database"
+name = "database-example"
 version = "0.1.0"
 edition = "2024"
 publish = false

--- a/book/examples/open-api/Cargo.toml
+++ b/book/examples/open-api/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "open-api-example"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+roadster = { path = "../../.." }
+aide = { workspace = true }
+tracing = { workspace = true }
+serde = { workspace = true }
+schemars = { workspace = true }
+axum = { workspace = true }
+async-trait = { workspace = true }
+rusty-sidekiq = { workspace = true }
+tokio-util = { workspace = true }

--- a/book/examples/open-api/src/http/mod.rs
+++ b/book/examples/open-api/src/http/mod.rs
@@ -1,0 +1,44 @@
+use aide::axum::ApiRouter;
+use aide::axum::routing::get_with;
+use aide::transform::TransformOperation;
+use axum::extract::State;
+use axum::{Json, Router};
+use roadster::api::http::build_path;
+use roadster::app::context::AppContext;
+use roadster::error::RoadsterResult;
+use roadster::service::http::builder::HttpServiceBuilder;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+
+const BASE: &str = "/api";
+
+pub fn http_service(state: &AppContext) -> HttpServiceBuilder<AppContext> {
+    HttpServiceBuilder::new(Some(BASE), state)
+        // Create your routes as an `ApiRouter` in order to include it in the OpenAPI schema.
+        .api_router(
+            ApiRouter::new()
+                // Register a `GET` route on the `ApiRouter`
+                .api_route(
+                    &build_path(BASE, "/example"),
+                    get_with(example_get, example_get_docs),
+                ),
+        )
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ExampleResponse {}
+
+#[instrument(skip_all)]
+pub async fn example_get(
+    State(_state): State<AppContext>,
+) -> RoadsterResult<Json<ExampleResponse>> {
+    Ok(Json(ExampleResponse {}))
+}
+
+pub fn example_get_docs(op: TransformOperation) -> TransformOperation {
+    op.description("Example API.")
+        .tag("Example")
+        .response_with::<200, Json<ExampleResponse>, _>(|res| res.example(ExampleResponse {}))
+}

--- a/book/examples/open-api/src/lib.rs
+++ b/book/examples/open-api/src/lib.rs
@@ -1,0 +1,18 @@
+use crate::http::http_service;
+use roadster::app::RoadsterApp;
+use roadster::app::context::AppContext;
+
+mod http;
+
+fn build_app() -> RoadsterApp<AppContext> {
+    RoadsterApp::builder()
+        // Use the default `AppContext` for this example
+        .state_provider(|context| Ok(context))
+        .add_service_provider(move |registry, state| {
+            Box::pin(async move {
+                registry.register_builder(http_service(state)).await?;
+                Ok(())
+            })
+        })
+        .build()
+}

--- a/book/examples/service/Cargo.toml
+++ b/book/examples/service/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "service"
+name = "service-example"
 version = "0.1.0"
 edition = "2024"
 publish = false

--- a/book/examples/service/src/http/mod.rs
+++ b/book/examples/service/src/http/mod.rs
@@ -17,7 +17,7 @@ const BASE: &str = "/api";
 
 /// Set up the [`HttpServiceBuilder`]. This will then be registered with the
 /// [`roadster::service::registry::ServiceRegistry`].
-pub async fn http_service(state: &AppContext) -> HttpServiceBuilder<AppContext> {
+pub fn http_service(state: &AppContext) -> HttpServiceBuilder<AppContext> {
     HttpServiceBuilder::new(Some(BASE), state)
         // Multiple routers can be registered and they will all be merged together using the
         // `axum::Router::merge` method.

--- a/book/examples/service/src/http/open_api.rs
+++ b/book/examples/service/src/http/open_api.rs
@@ -13,7 +13,7 @@ async fn open_api() -> RoadsterResult<()> {
         .add_service_provider(move |registry, state| {
             Box::pin(async move {
                 registry
-                    .register_builder(crate::http::http_service(state).await)
+                    .register_builder(crate::http::http_service(state))
                     .await?;
                 Ok(())
             })

--- a/book/src/features/open-api.md
+++ b/book/src/features/open-api.md
@@ -1,1 +1,51 @@
-# OpenAPI with [Aide](https://crates.io/crates/aide)
+# OpenAPI with [Aide](https://docs.rs/aide/0.14.1/aide/)
+
+If the `open-api` feature is enabled, an OpenAPI schema can be built for the app's Axum API by registering API routes
+using [Aide](https://docs.rs/aide/0.14.1/aide/). The schema will then be generated and served at the
+`/api/_docs/api.json` route by default, and is also accessible via CLI commands or the [
+`HttpService#open_api_schema`](https://docs.rs/roadster/latest/roadster/service/http/service/struct.HttpService.html#method.open_api_schema)
+method.
+
+## Register routes
+
+OpenAPI routes are registered with Aide's [`ApiRouter`](https://docs.rs/aide/0.14.1/aide/axum/struct.ApiRouter.html),
+which has a similar API to Axum's [`Router`](https://docs.rs/axum/latest/axum/struct.Router.html).
+
+```rust,ignore
+{{#include ../../examples/open-api/src/http/mod.rs:14:}}
+```
+
+## Get schema via API route
+
+By default, the generated schema will be served at `/api/_docs/api.json`. This route can be configured via the
+`service.http.default-routes.api-schema.route` config field.
+
+```shell
+# First, run your app
+cargo run
+
+# In a separate shell or browser, navigate to the API, e.g.
+curl localhost:3000/api/_docs/api.json
+```
+
+## Get schema via CLI
+
+The schema can also be generated via a CLI command
+
+```shell
+cargo run -- roadster open-api -o $HOME/open-api.json
+```
+
+## Get schema from the `HttpService`
+
+The schema can also be generated programmatically using the `HttpService` directly.
+
+```rust,ignore
+{{#include ../../examples/service/src/http/open_api.rs:7:}}
+```
+
+## Docs.rs links
+
+- [Aide](https://docs.rs/aide/0.14.1/aide/)
+- [`HttpService`](https://docs.rs/roadster/latest/roadster/service/http/service/struct.HttpService.html)
+- [`HttpServiceBuilder`](https://docs.rs/roadster/latest/roadster/service/http/builder/struct.HttpServiceBuilder.html)


### PR DESCRIPTION
It's largely duplicated with part of the http service chapter, so maybe we don't super need it, but I'll keep it for now.