### PR TITLE
feat: Use the test name as the test db name

### DIFF
--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -5,6 +5,7 @@ use crate::error::RoadsterResult;
 use crate::health::check::HealthCheck;
 use crate::health::check::registry::HealthCheckRegistry;
 use axum_core::extract::FromRef;
+#[cfg(all(feature = "db-sql", feature = "testing"))]
 use itertools::Itertools;
 #[cfg(feature = "db-sea-orm")]
 use sea_orm::DatabaseConnection;
@@ -825,6 +826,7 @@ async fn sidekiq_redis_test_container(
     Ok(container)
 }
 
+#[cfg(all(feature = "db-sql", feature = "testing"))]
 const MAX_DB_NAME_LENGTH: usize = 63;
 
 #[cfg(all(feature = "db-sql", feature = "testing"))]

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -5,9 +5,7 @@ use crate::error::RoadsterResult;
 use crate::health::check::HealthCheck;
 use crate::health::check::registry::HealthCheckRegistry;
 use axum_core::extract::FromRef;
-use http_body_util::BodyExt;
 use itertools::Itertools;
-use num_traits::Saturating;
 #[cfg(feature = "db-sea-orm")]
 use sea_orm::DatabaseConnection;
 use std::sync::{Arc, OnceLock, Weak};

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -5,6 +5,9 @@ use crate::error::RoadsterResult;
 use crate::health::check::HealthCheck;
 use crate::health::check::registry::HealthCheckRegistry;
 use axum_core::extract::FromRef;
+use http_body_util::BodyExt;
+use itertools::Itertools;
+use num_traits::Saturating;
 #[cfg(feature = "db-sea-orm")]
 use sea_orm::DatabaseConnection;
 use std::sync::{Arc, OnceLock, Weak};
@@ -824,6 +827,8 @@ async fn sidekiq_redis_test_container(
     Ok(container)
 }
 
+const MAX_DB_NAME_LENGTH: usize = 63;
+
 #[cfg(all(feature = "db-sql", feature = "testing"))]
 #[cfg_attr(test, allow(dead_code))]
 async fn create_temporary_test_db(
@@ -834,7 +839,49 @@ async fn create_temporary_test_db(
     }
 
     let original_uri = config.database.uri.clone();
-    let db_name = uuid::Uuid::new_v4().to_string();
+
+    let thread_name = std::thread::current()
+        .name()
+        .ok_or_else(|| crate::error::other::OtherError::Message("Thread name missing".to_owned()))?
+        .to_string();
+    let mod_path = thread_name
+        .split("::")
+        .filter(|segment| !segment.starts_with("case_"))
+        .map(|segment| segment.get(0..1).unwrap_or(""))
+        .collect_vec()
+        .into_iter()
+        .rev()
+        .get(1..)
+        .rev()
+        .join("/");
+    let prefix = format!("tmp/{mod_path}/");
+    let suffix = format!("/{}", chrono::Utc::now().timestamp());
+
+    let test_name = thread_name
+        .split("::")
+        .filter(|segment| !segment.starts_with("case_"))
+        .last()
+        .unwrap_or("");
+    let case_name = thread_name
+        .split("::")
+        .filter(|segment| segment.starts_with("case_"))
+        .last()
+        .map(|case_name| format!("/{case_name}"))
+        .unwrap_or_else(|| "".to_owned());
+    let test_name = format!("{test_name}{case_name}");
+
+    let name_len = prefix.len() + suffix.len() + test_name.len();
+    let start_index = if name_len > MAX_DB_NAME_LENGTH {
+        name_len - MAX_DB_NAME_LENGTH
+    } else {
+        0
+    };
+    let test_name_truncated = test_name.get(start_index..test_name.len()).ok_or_else(|| {
+        crate::error::other::OtherError::Message(
+            "Invalid indexes used to truncate test name".to_owned(),
+        )
+    })?;
+    let db_name = format!("{prefix}{test_name_truncated}{suffix}");
     tracing::debug!("Creating test db {db_name} using connection {original_uri}");
 
     #[allow(unused_variables)]

--- a/src/testing/snapshot.rs
+++ b/src/testing/snapshot.rs
@@ -306,7 +306,7 @@ pub fn snapshot_redact_timestamp(settings: &mut Settings) -> &mut Settings {
 ///
 /// See: <https://github.com/adriangb/pgpq/blob/b0b0f8c77c862c0483d81571e76f3a2b746136fc/pgpq/src/lib.rs#L649-L669>
 /// See: <https://github.com/la10736/rstest/issues/177>
-fn description_from_current_thread() -> String {
+pub(crate) fn description_from_current_thread() -> String {
     let thread_name = current().name().unwrap_or("").to_string();
     description_from_thread_name(&thread_name)
 }

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -204,11 +204,11 @@ pub fn init_tracing(
     #[cfg(feature = "otel")]
     let registry = { registry.with(oltp_traces_layer).with(otlp_metrics_layer) };
 
-    #[cfg_attr(test, allow(unused_variables))]
+    #[cfg_attr(any(test, feature = "testing"), allow(unused_variables))]
     let result = registry.try_init();
 
     // When running with cargo test, the registry is not reset between tests.
-    #[cfg(not(test))]
+    #[cfg(not(any(test, feature = "testing")))]
     result?;
 
     Ok(())


### PR DESCRIPTION
Updates the test db name to be of the format
`tmp/<mod_path_initials>/<test_name>[/<case_name>]/<timestamp>`.
This will make it easier to find the DB involved in a test,
including allowing sorting by the test run timestamp.

Closes https://github.com/roadster-rs/roadster/issues/736