### PR TITLE
chore!: Migrate from `typed-builder` to `bon`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ dependencies = [
  "aide",
  "async-trait",
  "axum",
+ "bon",
  "leptos",
  "lettre",
  "roadster",
@@ -1503,7 +1504,6 @@ dependencies = [
  "serde",
  "tokio-util",
  "tracing",
- "typed-builder 0.21.0",
  "uuid",
 ]
 
@@ -3942,6 +3942,7 @@ name = "powerset_matrix"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bon",
  "cargo-manifest",
  "clap",
  "insta",
@@ -3954,7 +3955,6 @@ dependencies = [
  "serde_json",
  "strum 0.27.1",
  "strum_macros",
- "typed-builder 0.21.0",
 ]
 
 [[package]]
@@ -4678,7 +4678,6 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "typed-builder 0.21.0",
  "url",
  "uuid",
  "validator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,6 @@ chrono = { workspace = true, features = ["serde"] }
 byte-unit = { workspace = true }
 convert_case = { workspace = true }
 const_format = { workspace = true }
-typed-builder = { workspace = true }
 bon = { workspace = true }
 num-traits = { workspace = true }
 validator = { workspace = true }
@@ -280,7 +279,6 @@ vergen-gitcl = { version = "1.0.0" }
 reqwest = { version = "0.12.8", default-features = false, features = ["rustls-tls", "charset", "http2", "macos-system-configuration"] }
 itertools = "0.14.0"
 cargo-manifest = "0.19.1"
-typed-builder = "0.21.0"
 bon = "3.0.0"
 rand = "0.9.0"
 thiserror = "2.0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -279,7 +279,7 @@ vergen-gitcl = { version = "1.0.0" }
 reqwest = { version = "0.12.8", default-features = false, features = ["rustls-tls", "charset", "http2", "macos-system-configuration"] }
 itertools = "0.14.0"
 cargo-manifest = "0.19.1"
-bon = "3.0.0"
+bon = "3.1.0"
 rand = "0.9.0"
 thiserror = "2.0.9"
 uuid = { version = "1.11.0", features = ["v4", "serde"] }

--- a/book/examples/email/Cargo.toml
+++ b/book/examples/email/Cargo.toml
@@ -14,7 +14,7 @@ axum = { workspace = true }
 async-trait = { workspace = true }
 tokio-util = { workspace = true }
 uuid = { workspace = true }
-typed-builder = { workspace = true }
 lettre = { workspace = true }
 sendgrid = { workspace = true }
+bon = { workspace = true }
 leptos = "0.8.0-alpha"

--- a/book/examples/email/src/worker/email/sendgrid.rs
+++ b/book/examples/email/src/worker/email/sendgrid.rs
@@ -6,10 +6,9 @@ use roadster::worker::Worker;
 use sendgrid::v3::{Email, Message, Personalization};
 use serde::{Deserialize, Serialize};
 use tracing::{info, instrument};
-use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
-#[derive(Debug, TypedBuilder, Serialize, Deserialize)]
+#[derive(Debug, bon::Builder, Serialize, Deserialize)]
 pub struct EmailConfirmationSendgridArgs {
     user_id: Uuid,
 }

--- a/book/examples/email/src/worker/email/smtp.rs
+++ b/book/examples/email/src/worker/email/smtp.rs
@@ -9,10 +9,9 @@ use roadster::worker::Worker;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use tracing::{info, instrument};
-use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
-#[derive(Debug, TypedBuilder, Serialize, Deserialize)]
+#[derive(Debug, bon::Builder, Serialize, Deserialize)]
 pub struct EmailConfirmationPlainTextArgs {
     user_id: Uuid,
 }

--- a/book/examples/email/src/worker/email/smtp_leptos.rs
+++ b/book/examples/email/src/worker/email/smtp_leptos.rs
@@ -10,10 +10,9 @@ use roadster::worker::Worker;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use tracing::{info, instrument};
-use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
-#[derive(Debug, TypedBuilder, Serialize, Deserialize)]
+#[derive(Debug, bon::Builder, Serialize, Deserialize)]
 pub struct EmailConfirmationHtmlArgs {
     user_id: Uuid,
 }

--- a/private/powerset_matrix/Cargo.toml
+++ b/private/powerset_matrix/Cargo.toml
@@ -11,13 +11,13 @@ cargo-manifest = { workspace = true }
 itertools = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-typed-builder = { workspace = true }
 rand = { workspace = true, features = ["std_rng"] }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
+bon = { workspace = true }
 
 [dev-dependencies]
 roadster = { path = "../..", default-features = false, features = ["testing"] }

--- a/private/powerset_matrix/src/cli.rs
+++ b/private/powerset_matrix/src/cli.rs
@@ -1,8 +1,7 @@
 use clap::Parser;
 use strum_macros::{EnumString, IntoStaticStr};
-use typed_builder::TypedBuilder;
 
-#[derive(Debug, Default, Parser, TypedBuilder)]
+#[derive(Debug, Default, Parser, bon::Builder)]
 #[command(version, about)]
 #[non_exhaustive]
 pub struct Cli {
@@ -15,7 +14,6 @@ pub struct Cli {
     /// multiple groups of the given size. If not provided, the set will be provided in a single
     /// group.
     #[clap(short = 's', long)]
-    #[builder(default, setter(strip_option))]
     pub group_size: Option<usize>,
 
     /// The maximum "depth" of the "limited" powerset. Each subset of the "limited" powerset
@@ -24,12 +22,10 @@ pub struct Cli {
     pub limited_depth: usize,
 
     /// The number of subsets to return -- at random -- from the full powerset.
-    #[builder(default, setter(strip_option))]
     #[clap(short = 'c', long)]
     pub random_count: Option<usize>,
 
     /// The value to use to seed the PRNG used to pick from the full powerset.
-    #[builder(default, setter(strip_option))]
     #[clap(short = 'r', long)]
     pub random_seed: Option<u64>,
 }

--- a/private/powerset_matrix/src/main.rs
+++ b/private/powerset_matrix/src/main.rs
@@ -7,9 +7,8 @@ use powerset_matrix::cli::{Cli, Format};
 use powerset_matrix::powerset;
 use serde_derive::Serialize;
 use std::collections::BTreeSet;
-use typed_builder::TypedBuilder;
 
-#[derive(Debug, Serialize, TypedBuilder)]
+#[derive(Debug, Serialize, bon::Builder)]
 struct Output {
     indexes: Vec<usize>,
     powersets: Vec<Vec<String>>,

--- a/src/api/cli/roadster/migrate.rs
+++ b/src/api/cli/roadster/migrate.rs
@@ -110,7 +110,7 @@ where
         let steps_run = migrator
             .up(
                 &cli.state,
-                &UpArgs::builder().steps_opt(remaining_steps).build(),
+                &UpArgs::builder().maybe_steps(remaining_steps).build(),
             )
             .await?;
         total_steps_run += steps_run;
@@ -138,7 +138,7 @@ where
         let steps_run = migrator
             .down(
                 &cli.state,
-                &DownArgs::builder().steps_opt(remaining_steps).build(),
+                &DownArgs::builder().maybe_steps(remaining_steps).build(),
             )
             .await?;
         total_steps_run += steps_run;

--- a/src/app/metadata.rs
+++ b/src/app/metadata.rs
@@ -1,16 +1,14 @@
-use typed_builder::TypedBuilder;
-
 /// Metadata for the app. This is provided separately from the
 /// [`AppConfig`][crate::config::AppConfig] in order to allow the consumer to provide
 /// metadata, such as the app version, that is best determined dynamically.
-#[derive(Debug, Default, Clone, TypedBuilder)]
+#[derive(Debug, Default, Clone, bon::Builder)]
 #[non_exhaustive]
 pub struct AppMetadata {
     /// The name of the app. If not provided, Roadster will use the value from
     /// the [config][crate::config::App].
-    #[builder(default, setter(strip_option))]
+    #[builder(into)]
     pub name: Option<String>,
     /// The version of the app. For example, the cargo package version or the git commit sha.
-    #[builder(default, setter(strip_option))]
+    #[builder(into)]
     pub version: Option<String>,
 }

--- a/src/app/snapshots/roadster__app__prepare__tests__prepare_options_test.snap
+++ b/src/app/snapshots/roadster__app__prepare__tests__prepare_options_test.snap
@@ -3,11 +3,11 @@ source: src/app/prepare.rs
 expression: options
 ---
 PrepareOptions {
+    config_sources: [],
     env: Some(
         Test,
     ),
     parse_cli: false,
     config_dir: None,
-    config_sources: [],
     config: None,
 }

--- a/src/db/migration/mod.rs
+++ b/src/db/migration/mod.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use axum_core::extract::FromRef;
 use serde_derive::Serialize;
 use strum_macros::{EnumString, IntoStaticStr};
-use typed_builder::TypedBuilder;
 
 #[cfg(feature = "db-diesel")]
 pub mod diesel;
@@ -17,29 +16,27 @@ pub mod diesel;
 pub mod sea_orm;
 
 #[serde_with::skip_serializing_none]
-#[derive(Debug, Serialize, TypedBuilder)]
+#[derive(Debug, Serialize, bon::Builder)]
 #[cfg_attr(feature = "cli", derive(clap::Parser))]
 #[non_exhaustive]
 pub struct UpArgs {
     /// The number of pending migration steps to apply.
     #[cfg_attr(feature = "cli", clap(short = 'n', long))]
-    #[builder(default, setter(strip_option(fallback = steps_opt)))]
     pub steps: Option<usize>,
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Debug, Serialize, TypedBuilder)]
+#[derive(Debug, Serialize, bon::Builder)]
 #[cfg_attr(feature = "cli", derive(clap::Parser))]
 #[non_exhaustive]
 pub struct DownArgs {
     /// The number of applied migration steps to roll back.
     #[cfg_attr(feature = "cli", clap(short = 'n', long))]
-    #[builder(default, setter(strip_option(fallback = steps_opt)))]
     pub steps: Option<usize>,
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Debug, Serialize, TypedBuilder)]
+#[derive(Debug, Serialize, bon::Builder)]
 pub struct MigrationInfo {
     pub name: String,
     pub status: MigrationStatus,

--- a/src/db/migration/sea_orm/schema.rs
+++ b/src/db/migration/sea_orm/schema.rs
@@ -7,7 +7,6 @@
 
 use crate::db::migration::sea_orm::timestamp::Timestamps;
 use sea_orm_migration::{prelude::*, schema::*};
-use typed_builder::TypedBuilder;
 
 /// Create a table if it does not exist yet and add some default columns
 /// (e.g., create/update timestamps).
@@ -48,7 +47,7 @@ where
 }
 
 /// Configuration options for creating an `IDENTITY` column.
-#[derive(TypedBuilder)]
+#[derive(bon::Builder)]
 pub struct IdentityOptions {
     /// If `true`, will add `ALWAYS` to the column definition, which will prevent the application
     /// from providing a value for the column. If the application needs to be able to set the

--- a/src/middleware/http/auth/jwt/ietf.rs
+++ b/src/middleware/http/auth/jwt/ietf.rs
@@ -6,23 +6,20 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::serde_as;
 use std::collections::BTreeMap;
-use typed_builder::TypedBuilder;
 
 /// JWT Claims. Provides fields for the default/recommended registered claim names. Additional
 /// claim names are collected in the `custom` map.
 /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4>
 #[serde_as]
-#[derive(Debug, Clone, Deserialize, Serialize, TypedBuilder)]
+#[derive(Debug, Clone, Deserialize, Serialize, bon::Builder)]
 #[non_exhaustive]
 pub struct Claims<C = BTreeMap<String, Value>> {
     /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.1>
     #[serde(rename = "iss")]
-    #[builder(default, setter(strip_option))]
     pub issuer: Option<UriOrString>,
 
     /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.2>
     #[serde(rename = "sub")]
-    #[builder(default, setter(strip_option))]
     pub subject: Option<Subject>,
 
     /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.3>
@@ -39,18 +36,16 @@ pub struct Claims<C = BTreeMap<String, Value>> {
     /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.5>
     #[serde(rename = "nbf")]
     #[serde_as(as = "Option<serde_with::TimestampSeconds>")]
-    #[builder(default, setter(strip_option))]
     pub not_before: Option<DateTime<Utc>>,
 
     /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.6>
     #[serde(rename = "iat")]
     #[serde_as(as = "Option<serde_with::TimestampSeconds>")]
-    #[builder(default, setter(strip_option))]
     pub issued_at: Option<DateTime<Utc>>,
 
     /// See: <https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.7>
     #[serde(rename = "jti")]
-    #[builder(default, setter(strip_option))]
+    #[builder(into)]
     pub jwt_id: Option<String>,
 
     #[serde(flatten)]

--- a/src/middleware/http/auth/jwt/mod.rs
+++ b/src/middleware/http/auth/jwt/mod.rs
@@ -23,7 +23,6 @@ use jsonwebtoken::{DecodingKey, Header, TokenData, Validation, decode};
 use serde_derive::{Deserialize, Serialize};
 #[cfg(not(any(feature = "jwt-ietf", feature = "jwt-openid")))]
 use serde_json::Value as Claims;
-use typed_builder::TypedBuilder;
 use url::Url;
 use uuid::Uuid;
 
@@ -73,7 +72,8 @@ where
 /// If the functionality to extract from a cookie is not required, it's recommended to use
 /// the normal [`Jwt`] directly.
 #[cfg_attr(feature = "open-api", derive(aide::OperationIo))]
-#[derive(Deserialize, Serialize, TypedBuilder)]
+#[serde_with::skip_serializing_none]
+#[derive(Deserialize, Serialize, bon::Builder)]
 #[non_exhaustive]
 pub struct JwtCsrf<C = Claims> {
     pub token: Jwt<C>,

--- a/src/middleware/http/auth/jwt/openid.rs
+++ b/src/middleware/http/auth/jwt/openid.rs
@@ -5,7 +5,6 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::serde_as;
 use std::collections::BTreeMap;
-use typed_builder::TypedBuilder;
 use url::Url;
 
 use crate::util::serde::{UriOrString, deserialize_from_str, serialize_to_str};
@@ -14,7 +13,7 @@ use crate::util::serde::{UriOrString, deserialize_from_str, serialize_to_str};
 /// claim names are collected in the `custom` map.
 /// See: <https://openid.net/specs/openid-connect-core-1_0.html#IDToken>
 #[serde_as]
-#[derive(Debug, Clone, Deserialize, Serialize, TypedBuilder)]
+#[derive(Debug, Clone, Deserialize, Serialize, bon::Builder)]
 #[non_exhaustive]
 pub struct Claims<C = BTreeMap<String, Value>> {
     #[serde(rename = "iss")]
@@ -35,14 +34,12 @@ pub struct Claims<C = BTreeMap<String, Value>> {
     pub issued_at: DateTime<Utc>,
 
     #[serde_as(as = "Option<serde_with::TimestampSeconds>")]
-    #[builder(setter(strip_option))]
     pub auth_time: Option<DateTime<Utc>>,
 
-    #[builder(setter(strip_option))]
+    #[builder(into)]
     pub nonce: Option<String>,
 
     #[serde(rename = "acr")]
-    #[builder(setter(strip_option))]
     pub auth_cxt_class_reference: Option<Acr>,
 
     #[serde(rename = "amr", default, skip_serializing_if = "Vec::is_empty")]
@@ -53,7 +50,6 @@ pub struct Claims<C = BTreeMap<String, Value>> {
     /// beyond the scope of this specification are used; therefore, implementations not using such
     /// extensions are encouraged to not use azp and to ignore it when it does occur."
     #[serde(rename = "azp")]
-    #[builder(setter(strip_option))]
     pub authorized_party: Option<UriOrString>,
 
     #[serde(flatten)]

--- a/src/service/function/service.rs
+++ b/src/service/function/service.rs
@@ -6,7 +6,6 @@ use axum_core::extract::FromRef;
 use std::future::Future;
 use std::marker::PhantomData;
 use tokio_util::sync::CancellationToken;
-use typed_builder::TypedBuilder;
 
 /// A generic [Service] to allow creating a service from an async function.
 ///
@@ -40,7 +39,7 @@ use typed_builder::TypedBuilder;
 ///     .add_service(service)
 ///     .build();
 /// ```
-#[derive(TypedBuilder)]
+#[derive(bon::Builder)]
 pub struct FunctionService<S, F, Fut>
 where
     S: Clone + Send + Sync + 'static,
@@ -48,12 +47,11 @@ where
     F: Send + Sync + Fn(S, CancellationToken) -> Fut,
     Fut: Send + Future<Output = RoadsterResult<()>>,
 {
-    #[builder(setter(into))]
+    #[builder(into)]
     name: String,
-    #[builder(default, setter(strip_option))]
     enabled: Option<bool>,
     function: F,
-    #[builder(default, setter(skip))]
+    #[builder(skip)]
     _state: PhantomData<S>,
 }
 

--- a/src/service/http/service.rs
+++ b/src/service/http/service.rs
@@ -132,12 +132,12 @@ impl HttpService {
     }
 }
 
-#[derive(Debug, serde_derive::Serialize, typed_builder::TypedBuilder)]
+#[derive(Debug, serde_derive::Serialize, bon::Builder)]
 #[cfg_attr(feature = "cli", derive(clap::Parser))]
 #[non_exhaustive]
 pub struct OpenApiArgs {
     /// The file to write the schema to. If not provided, will write to stdout.
-    #[builder(default, setter(strip_option))]
+    #[builder(into)]
     #[cfg_attr(feature = "cli", clap(short, long, value_name = "FILE", value_hint = clap::ValueHint::FilePath))]
     pub output: Option<PathBuf>,
 

--- a/src/worker/config.rs
+++ b/src/worker/config.rs
@@ -2,7 +2,6 @@ use crate::config::CustomConfig;
 use serde_derive::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
 use std::time::Duration;
-use typed_builder::TypedBuilder;
 use validator::Validate;
 
 /// Worker configuration options to use when enqueuing a job. Default values for these options can
@@ -10,7 +9,7 @@ use validator::Validate;
 /// basis by implementing the [`crate::worker::Worker::enqueue_config`] method.
 #[serde_as]
 #[skip_serializing_none]
-#[derive(Debug, Default, Clone, Validate, Serialize, Deserialize, TypedBuilder)]
+#[derive(Debug, Default, Clone, Validate, Serialize, Deserialize, bon::Builder)]
 #[serde(default, rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct EnqueueConfig {
@@ -23,7 +22,7 @@ pub struct EnqueueConfig {
     /// this queue name is not too long or else the queue name will be truncated when used
     /// with `pgmq`.
     #[serde(default)]
-    #[builder(default, setter(into, strip_option(fallback = queue_opt)))]
+    #[builder(into)]
     pub queue: Option<String>,
 
     #[serde(flatten, default)]
@@ -37,37 +36,32 @@ pub struct EnqueueConfig {
 /// basis by implementing the [`crate::worker::Worker::worker_config`] method.
 #[serde_as]
 #[skip_serializing_none]
-#[derive(Debug, Default, Clone, Validate, Serialize, Deserialize, TypedBuilder)]
+#[derive(Debug, Default, Clone, Validate, Serialize, Deserialize, bon::Builder)]
 #[serde(default, rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct WorkerConfig {
     /// True if Roadster should enforce a timeout on the app's workers. The default duration of
     /// the timeout can be configured with the `max-duration` option.
     #[serde(default)]
-    #[builder(default, setter(strip_option))]
     pub timeout: Option<bool>,
 
     /// The maximum duration workers should run for. The timeout is only enforced if `timeout`
     /// is `true`.
     #[serde(default)]
     #[serde_as(as = "Option<serde_with::DurationMilliSeconds>")]
-    #[builder(default, setter(strip_option))]
     pub max_duration: Option<Duration>,
 
     /// The worker retry configuration. If no configuration is provided, either in the app's config
     /// or for the [`crate::worker::Worker`], the worker will not retry.
     #[serde(flatten, default)]
-    #[builder(default, setter(strip_option))]
     pub retry_config: Option<RetryConfig>,
 
     #[cfg(feature = "worker-sidekiq")]
     #[serde(default)]
-    #[builder(default, setter(strip_option))]
     pub sidekiq: Option<SidekiqWorkerConfig>,
 
     #[cfg(feature = "worker-pg")]
     #[serde(default)]
-    #[builder(default, setter(strip_option))]
     pub pg: Option<PgWorkerConfig>,
 
     #[serde(flatten, default)]
@@ -78,25 +72,23 @@ pub struct WorkerConfig {
 
 #[serde_as]
 #[skip_serializing_none]
-#[derive(Debug, Default, Clone, Validate, Serialize, Deserialize, TypedBuilder)]
+#[derive(Debug, Default, Clone, Validate, Serialize, Deserialize, bon::Builder)]
 #[serde(default, rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct SidekiqWorkerConfig {
     /// See <https://docs.rs/rusty-sidekiq/latest/sidekiq/trait.Worker.html#method.disable_argument_coercion>
     #[serde(default)]
-    #[builder(default, setter(strip_option(fallback = disable_argument_coercion_opt)))]
     pub disable_argument_coercion: Option<bool>,
 }
 
 #[serde_as]
 #[skip_serializing_none]
-#[derive(Debug, Default, Clone, Validate, Serialize, Deserialize, TypedBuilder)]
+#[derive(Debug, Default, Clone, Validate, Serialize, Deserialize, bon::Builder)]
 #[serde(default, rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct RetryConfig {
     /// The maximum number of times a job should be retried on failure.
     #[serde(default)]
-    #[builder(default, setter(strip_option))]
     pub max_retries: Option<usize>,
 
     /// The delay between retries. If a [`BackoffStrategy`] is provided, this will be used as the
@@ -106,7 +98,6 @@ pub struct RetryConfig {
     /// this and instead uses a hard-coded delay.
     #[serde(default)]
     #[serde_as(as = "Option<serde_with::DurationMilliSeconds>")]
-    #[builder(default, setter(strip_option))]
     pub delay: Option<Duration>,
 
     /// An offset to add to the base `delay` to add jitter to the delay to avoid a "thundering herd"
@@ -117,7 +108,6 @@ pub struct RetryConfig {
     /// this and instead uses a hard-coded delay.
     #[serde(default)]
     #[serde_as(as = "Option<serde_with::DurationMilliSeconds>")]
-    #[builder(default, setter(strip_option))]
     pub delay_offset: Option<Duration>,
 
     /// The maximum duration to delay the retry.
@@ -126,7 +116,6 @@ pub struct RetryConfig {
     /// this and instead uses a hard-coded delay.
     #[serde(default)]
     #[serde_as(as = "Option<serde_with::DurationMilliSeconds>")]
-    #[builder(default, setter(strip_option))]
     pub max_delay: Option<Duration>,
 
     /// The retry delay backoff algorithm to use.
@@ -134,7 +123,6 @@ pub struct RetryConfig {
     /// Note: Not all worker backends will use this. For example, the Sidekiq backend does not use
     /// this and instead uses a hard-coded exponential backoff strategy.
     #[serde(default)]
-    #[builder(default, setter(strip_option))]
     pub backoff_strategy: Option<BackoffStrategy>,
 }
 
@@ -152,7 +140,7 @@ pub enum BackoffStrategy {
 
 #[serde_as]
 #[skip_serializing_none]
-#[derive(Debug, Default, Clone, Validate, Serialize, Deserialize, TypedBuilder)]
+#[derive(Debug, Default, Clone, Validate, Serialize, Deserialize, bon::Builder)]
 #[serde(default, rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct PgWorkerConfig {


### PR DESCRIPTION
The resulting APIs are mostly compatible. However, optional setters were renamed from `*_opt` to `maybe_*`.