### PR TITLE
feat!: Add `id` field to internal `Job` struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "unicode-xid",
+]
+
+[[package]]
 name = "deunicode"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4801,6 +4822,7 @@ dependencies = [
  "const_format",
  "convert_case 0.8.0",
  "cron",
+ "derive_more",
  "diesel",
  "diesel-async",
  "diesel_migrations",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "cfg-if",
  "clap",
  "config",
+ "cron",
  "roadster",
  "rusty-sidekiq",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default-diesel = ["default-common", "db-diesel-postgres-pool-async"]
 http = ["dep:axum", "dep:axum-extra", "dep:tower", "dep:tower-http", "dep:http-body-util", "dep:mime"]
 open-api = ["http", "dep:aide", "dep:schemars"]
 
-worker = ["dep:rand", "dep:num_cpus", "dep:cron"]
+worker = ["dep:rand", "dep:num_cpus", "dep:cron", "uuid/v7"]
 worker-sidekiq = ["worker", "dep:rusty-sidekiq", "dep:bb8"]
 worker-pg = ["worker", "db-sql", "dep:pgmq", "dep:sqlx", "sea-orm?/sqlx-postgres", "dep:log"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default-diesel = ["default-common", "db-diesel-postgres-pool-async"]
 http = ["dep:axum", "dep:axum-extra", "dep:tower", "dep:tower-http", "dep:http-body-util", "dep:mime"]
 open-api = ["http", "dep:aide", "dep:schemars"]
 
-worker = ["dep:rand", "dep:num_cpus", "dep:cron", "uuid/v7"]
+worker = ["dep:rand", "dep:num_cpus", "dep:cron", "uuid/v7", "dep:derive_more"]
 worker-sidekiq = ["worker", "dep:rusty-sidekiq", "dep:bb8"]
 worker-pg = ["worker", "db-sql", "dep:pgmq", "dep:sqlx", "sea-orm?/sqlx-postgres", "dep:log"]
 
@@ -112,6 +112,7 @@ lettre = { workspace = true, features = ["serde"], optional = true }
 sendgrid = { workspace = true, optional = true }
 
 # Workers
+derive_more = { workspace = true, features = ["display"], optional = true }
 ## Sidekiq
 rusty-sidekiq = { workspace = true, optional = true }
 num_cpus = { workspace = true, optional = true }
@@ -292,6 +293,7 @@ async-trait = "0.1.81"
 regex = "1.11.1"
 cron = { version = "0.15.0", features = ["serde"] }
 log = "0.4.27"
+derive_more = "2.0.0"
 
 # Build dependencies
 rustc_version = "0.4.1"

--- a/examples/app-builder/Cargo.toml
+++ b/examples/app-builder/Cargo.toml
@@ -35,6 +35,7 @@ clap = { workspace = true, features = ["derive"], optional = true }
 # The default `rss-stats` feature has a dependency that currently can't be satisfied (memchr: ~2.3)
 rusty-sidekiq = { workspace = true, default-features = false }
 serde = { workspace = true, features = ["derive"] }
+cron = { workspace = true }
 
 # Config
 config = { workspace = true, features = ["async"] }

--- a/examples/app-builder/src/lib.rs
+++ b/examples/app-builder/src/lib.rs
@@ -12,8 +12,10 @@ use roadster::error::RoadsterResult;
 use roadster::service::function::service::FunctionService;
 use roadster::service::http::service::HttpService;
 use roadster::service::worker::SidekiqWorkerService;
+use roadster::worker::PeriodicArgs;
 use roadster::worker::backend::sidekiq::processor::SidekiqProcessor;
 use std::future;
+use std::str::FromStr;
 use tokio_util::sync::CancellationToken;
 
 pub mod api;
@@ -132,6 +134,13 @@ pub fn build_app() -> App {
             Box::pin(async {
                 let processor = SidekiqProcessor::builder(state)
                     .register(ExampleWorker)?
+                    .register_periodic(
+                        ExampleWorker,
+                        PeriodicArgs::builder()
+                            .schedule(cron::Schedule::from_str("*/10 * * * * *")?)
+                            .args("foo".to_owned())
+                            .build(),
+                    )?
                     .build()
                     .await?;
                 registry.register_service(

--- a/examples/app-builder/src/lib.rs
+++ b/examples/app-builder/src/lib.rs
@@ -137,7 +137,7 @@ pub fn build_app() -> App {
                     .register_periodic(
                         ExampleWorker,
                         PeriodicArgs::builder()
-                            .schedule(cron::Schedule::from_str("*/10 * * * * *")?)
+                            .schedule(cron::Schedule::from_str("* * * * * *")?)
                             .args("foo".to_owned())
                             .build(),
                     )?

--- a/src/service/http/middleware/tracing/mod.rs
+++ b/src/service/http/middleware/tracing/mod.rs
@@ -3,6 +3,7 @@ pub mod req_res_logging;
 use crate::app::context::AppContext;
 use crate::error::RoadsterResult;
 use crate::service::http::middleware::Middleware;
+use crate::util::tracing::optional_trace_field;
 use axum::Router;
 use axum::extract::{FromRef, MatchedPath};
 use axum::http::{HeaderMap, HeaderName, HeaderValue, Request, Response};
@@ -18,7 +19,7 @@ use std::iter::{IntoIterator, Iterator};
 use std::str::FromStr;
 use std::time::Duration;
 use tower_http::trace::{MakeSpan, OnRequest, OnResponse, TraceLayer};
-use tracing::{Span, Value, error_span, field, info};
+use tracing::{Span, error_span, field, info};
 use url::Url;
 use validator::Validate;
 
@@ -217,15 +218,6 @@ fn get_query_redacted<B>(
         .join("&");
 
     Some(redacted)
-}
-
-fn optional_trace_field<T>(value: Option<T>) -> Box<dyn Value>
-where
-    T: ToString,
-{
-    value
-        .map(|x| Box::new(field::display(x.to_string())) as Box<dyn Value>)
-        .unwrap_or(Box::new(field::Empty))
 }
 
 #[derive(Debug, Clone)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -6,4 +6,5 @@ pub mod empty;
 pub(crate) mod redis;
 pub mod regex;
 pub mod serde;
+pub mod tracing;
 pub mod types;

--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -1,0 +1,10 @@
+use tracing::{Value, field};
+
+pub fn optional_trace_field<T>(value: Option<T>) -> Box<dyn Value>
+where
+    T: ToString,
+{
+    value
+        .map(|x| Box::new(field::display(x.to_string())) as Box<dyn Value>)
+        .unwrap_or(Box::new(field::Empty))
+}

--- a/src/worker/backend/sidekiq/enqueue.rs
+++ b/src/worker/backend/sidekiq/enqueue.rs
@@ -1,5 +1,6 @@
 use crate::app::context::AppContext;
 use crate::error::RoadsterResult;
+use crate::worker::job::Job;
 use crate::worker::{Enqueuer, Worker, enqueue};
 use async_trait::async_trait;
 use axum_core::extract::FromRef;
@@ -26,17 +27,17 @@ impl Enqueuer for SidekiqEnqueuer {
         enqueue::enqueue::<W, _, _, _, _, _>(
             state,
             args,
-            async |state, queue, job| -> RoadsterResult<()> {
+            async |state, queue, job: Job| -> RoadsterResult<()> {
                 let context = AppContext::from_ref(state);
                 // Todo: update `sidekiq` to return the job id?
                 ::sidekiq::perform_async(
                     context.redis_enqueue(),
                     job.metadata.worker_name.to_owned(),
                     queue.to_owned(),
-                    &job.args,
+                    &job,
                 )
                 .await?;
-                debug!("Job enqueued");
+                debug!(job.id = %job.metadata.id, "Job enqueued");
                 Ok(())
             },
         )
@@ -59,7 +60,7 @@ impl Enqueuer for SidekiqEnqueuer {
         enqueue::enqueue::<W, _, _, _, _, _>(
             state,
             args,
-            async move |state, queue, job| -> RoadsterResult<()> {
+            async move |state, queue, job: Job| -> RoadsterResult<()> {
                 let context = AppContext::from_ref(state);
                 // Todo: update `sidekiq` to return the job id?
                 ::sidekiq::perform_in(
@@ -67,10 +68,10 @@ impl Enqueuer for SidekiqEnqueuer {
                     delay,
                     job.metadata.worker_name.to_owned(),
                     queue.to_owned(),
-                    &job.args,
+                    &job,
                 )
                 .await?;
-                debug!(job.delay = delay.as_secs(), "Job enqueued");
+                debug!(job.id = %job.metadata.id, job.delay = delay.as_secs(), "Job enqueued");
                 Ok(())
             },
         )
@@ -92,7 +93,7 @@ impl Enqueuer for SidekiqEnqueuer {
         enqueue::enqueue_batch::<W, _, _, _, _, _>(
             state,
             args,
-            async |state, queue, jobs| -> RoadsterResult<()> {
+            async |state, queue, jobs: Vec<Job>| -> RoadsterResult<()> {
                 let context = AppContext::from_ref(state);
                 // Todo: update `sidekiq` to return the job ids?
                 // Todo: update `sidekiq` to batch enqueue?
@@ -101,10 +102,10 @@ impl Enqueuer for SidekiqEnqueuer {
                         context.redis_enqueue(),
                         job.metadata.worker_name.to_owned(),
                         queue.to_owned(),
-                        &job.args,
+                        &job,
                     )
                     .await?;
-                    debug!("Job enqueued");
+                    debug!(job.id = %job.metadata.id, "Job enqueued");
                 }
                 Ok(())
             },
@@ -128,7 +129,7 @@ impl Enqueuer for SidekiqEnqueuer {
         enqueue::enqueue_batch::<W, _, _, _, _, _>(
             state,
             args,
-            async move |state, queue, jobs| -> RoadsterResult<()> {
+            async move |state, queue, jobs: Vec<Job>| -> RoadsterResult<()> {
                 let context = AppContext::from_ref(state);
                 // Todo: update `sidekiq` to return the job ids?
                 // Todo: update `sidekiq` to batch enqueue?
@@ -138,10 +139,10 @@ impl Enqueuer for SidekiqEnqueuer {
                         delay,
                         job.metadata.worker_name.to_owned(),
                         queue.to_owned(),
-                        &job.args,
+                        &job,
                     )
                     .await?;
-                    debug!(job.delay = delay.as_secs(), "Job enqueued");
+                    debug!(job.id = %job.metadata.id, job.delay = delay.as_secs(), "Job enqueued");
                 }
                 Ok(())
             },

--- a/src/worker/backend/sidekiq/processor/builder.rs
+++ b/src/worker/backend/sidekiq/processor/builder.rs
@@ -253,19 +253,14 @@ where
                         entries being created in Redis. So, for periodic jobs, we use the periodic hash
                         as the job ID.
                          */
-                        let id = job
-                            .metadata
-                            .periodic
-                            .as_ref()
-                            .map(|p| p.hash)
-                            .map(|hash| hash.to_string());
+                        let id = job.metadata.periodic.as_ref().map(|p| p.hash);
                         let id = if let Some(id) = id {
                             id
                         } else {
                             warn!("Periodic job created with empty hash/id");
                             Default::default()
                         };
-                        job.metadata.id = id.clone();
+                        job.metadata.id = id.into();
                         let builder = ::sidekiq::periodic::builder(&args.schedule.to_string())?
                             .args(job)?
                             .queue(queue.clone());

--- a/src/worker/job.rs
+++ b/src/worker/job.rs
@@ -1,3 +1,5 @@
+use uuid::Uuid;
+
 // Todo: Not sure if this should be public yet.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, bon::Builder, Eq, PartialEq)]
@@ -14,6 +16,8 @@ pub(crate) struct Job {
 #[non_exhaustive]
 #[cfg(any(feature = "worker-sidekiq", feature = "worker-pg"))]
 pub(crate) struct JobMetadata {
+    #[builder(default = Uuid::now_v7())]
+    pub(crate) id: Uuid,
     #[builder(into)]
     pub(crate) worker_name: String,
     pub(crate) periodic: Option<PeriodicConfig>,
@@ -130,6 +134,8 @@ mod tests {
     #[test]
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn job_serde() {
+        let _case = TestCase::new();
+
         let job = Job::builder()
             .args(serde_json::json!({"foo": "bar"}))
             .metadata(
@@ -151,6 +157,8 @@ mod tests {
     #[test]
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn job_serde_no_periodic() {
+        let _case = TestCase::new();
+
         let job = Job::builder()
             .args(serde_json::json!({"foo": "bar"}))
             .metadata(JobMetadata::builder().worker_name("foo").build())

--- a/src/worker/job.rs
+++ b/src/worker/job.rs
@@ -16,8 +16,8 @@ pub(crate) struct Job {
 #[non_exhaustive]
 #[cfg(any(feature = "worker-sidekiq", feature = "worker-pg"))]
 pub(crate) struct JobMetadata {
-    #[builder(default = Uuid::now_v7())]
-    pub(crate) id: Uuid,
+    #[builder(default = Uuid::now_v7().to_string())]
+    pub(crate) id: String,
     #[builder(into)]
     pub(crate) worker_name: String,
     pub(crate) periodic: Option<PeriodicConfig>,
@@ -42,7 +42,6 @@ impl From<&crate::worker::PeriodicArgsJson> for Job {
         value.hash(&mut hash);
         let hash = hash.finish();
 
-        // let hash = periodic_hash(&value.worker_name, &value.schedule, &value.args);
         Job::builder()
             .args(value.args.clone())
             .metadata(

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -201,6 +201,7 @@ where
     {
         use std::any::Any;
 
+        let type_id = worker.type_id();
         let worker = std::sync::Arc::new(worker);
 
         #[cfg(feature = "bench")]
@@ -209,7 +210,7 @@ where
         Ok(Self {
             inner: std::sync::Arc::new(WorkerWrapperInner {
                 name: W::name(),
-                type_id: worker.type_id(),
+                type_id,
                 enqueue_config,
                 worker_config: worker.worker_config(state),
                 worker_fn: Box::new(move |state: &S, args: serde_json::Value| {

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -10,6 +10,7 @@ pub use crate::worker::backend::sidekiq::enqueue::SidekiqEnqueuer;
 pub use crate::worker::backend::sidekiq::processor::SidekiqProcessor;
 use crate::worker::config::{EnqueueConfig, WorkerConfig};
 use crate::worker::enqueue::Enqueuer;
+#[cfg(any(feature = "worker-sidekiq", feature = "worker-pg"))]
 use crate::worker::job::JobMetadata;
 use async_trait::async_trait;
 use axum_core::extract::FromRef;

--- a/src/worker/snapshots/roadster__worker__job__tests__job_serde@job_serde.snap
+++ b/src/worker/snapshots/roadster__worker__job__tests__job_serde@job_serde.snap
@@ -1,0 +1,17 @@
+---
+source: src/worker/job.rs
+expression: job
+---
+{
+  "metadata": {
+    "id": "[uuid]",
+    "worker_name": "foo",
+    "periodic": {
+      "hash": 1234,
+      "schedule": "* * * * * *"
+    }
+  },
+  "args": {
+    "foo": "bar"
+  }
+}

--- a/src/worker/snapshots/roadster__worker__job__tests__job_serde_no_periodic@job_serde_no_periodic.snap
+++ b/src/worker/snapshots/roadster__worker__job__tests__job_serde_no_periodic@job_serde_no_periodic.snap
@@ -1,0 +1,13 @@
+---
+source: src/worker/job.rs
+expression: job
+---
+{
+  "metadata": {
+    "id": "[uuid]",
+    "worker_name": "foo"
+  },
+  "args": {
+    "foo": "bar"
+  }
+}


### PR DESCRIPTION
To help with tracking background jobs in a uniform way across different worker backends, add an `id` field to our internal `Job` struct. The ID is logged at the debug level when the job is enqueued, at error level when an error occurs, and is added to the trace span around the worker's `handle` method.

This is technically a breaking change because any jobs that were enqueued before this change will not deserialize properly due to the missing `id` field. Additionally, our sidekiq integration was changed to enqueue the entire `Job` struct instead of just the args.