### PR TITLE
chore!: Remove sidekiq and sea-orm from default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,11 +111,11 @@ jobs:
           length=${#features[@]}
           i=1
           for feature_list in "${features[@]}"; do
-            echo "::group::[$i/$length]: cargo nextest run --no-fail-fast --features $feature_list"
-            cargo nextest run --no-fail-fast --features "$feature_list"
+            echo "::group::[$i/$length]: cargo nextest run --no-fail-fast --no-default-features --features $feature_list"
+            cargo nextest run --no-fail-fast --no-default-features --features "$feature_list"
             echo "::endgroup::"
-            echo "::group::[$i/$length]: cargo test --doc --no-fail-fast --features $feature_list"
-            cargo test --doc --no-fail-fast --features "$feature_list"
+            echo "::group::[$i/$length]: cargo test --doc --no-fail-fast --no-default-features --features $feature_list"
+            cargo test --doc --no-fail-fast --no-default-features --features "$feature_list"
             cargo clean -p roadster
             i=$(expr $i + 1)
             echo "::endgroup::"
@@ -179,8 +179,8 @@ jobs:
           length=${#features[@]}
           i=1
           for feature_list in "${features[@]}"; do
-            echo "::group::[$i/$length]: cargo clippy --features $feature_list -- -D warnings"
-            cargo clippy --features "$feature_list" -- -D warnings
+            echo "::group::[$i/$length]: cargo clippy --no-default-features --features $feature_list -- -D warnings"
+            cargo clippy --no-default-features --features "$feature_list" -- -D warnings
             cargo clean -p roadster
             i=$(expr $i + 1)
             echo "::endgroup::"

--- a/.github/workflows/feature_powerset.yml
+++ b/.github/workflows/feature_powerset.yml
@@ -95,11 +95,11 @@ jobs:
           length=${#features[@]}
           i=1
           for feature_list in "${features[@]}"; do
-            echo "::group::[$i/$length]: cargo nextest run --no-fail-fast --features $feature_list"
-            cargo nextest run --no-fail-fast --features "$feature_list"
+            echo "::group::[$i/$length]: cargo nextest run --no-fail-fast --no-default-features --features $feature_list"
+            cargo nextest run --no-fail-fast --no-default-features --features "$feature_list"
             echo "::endgroup::"
-            echo "::group::[$i/$length]: cargo test --doc --no-fail-fast --features $feature_list"
-            cargo test --doc --no-fail-fast --features "$feature_list"
+            echo "::group::[$i/$length]: cargo test --doc --no-fail-fast --no-default-features --features $feature_list"
+            cargo test --doc --no-fail-fast --no-default-features --features "$feature_list"
             cargo clean -p roadster
             i=$(expr $i + 1)
             echo "::endgroup::"
@@ -124,8 +124,8 @@ jobs:
           length=${#features[@]}
           i=1
           for feature_list in "${features[@]}"; do
-            echo "::group::[$i/$length]: cargo check --no-dev-deps --features $feature_list"
-            cargo check --features "$feature_list"
+            echo "::group::[$i/$length]: cargo check --no-dev-deps --no-default-features --features $feature_list"
+            cargo check --no-default-features --features "$feature_list"
             cargo clean -p roadster
             i=$(expr $i + 1)
             echo "::endgroup::"
@@ -150,8 +150,8 @@ jobs:
           length=${#features[@]}
           i=1
           for feature_list in "${features[@]}"; do
-            echo "::group::[$i/$length]: cargo clippy --features $feature_list -- -D warnings "
-            cargo clippy --features "$feature_list" -- -D warnings
+            echo "::group::[$i/$length]: cargo clippy --no-default-features --features $feature_list -- -D warnings "
+            cargo clippy --no-default-features --features "$feature_list" -- -D warnings
             cargo clean -p roadster
             i=$(expr $i + 1)
             echo "::endgroup::"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,7 @@ rust-version = "1.85"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["default-common", "db-sea-orm"]
-default-common = ["worker-sidekiq", "open-api", "jwt-ietf", "cli", "otel"]
-# The same as `default`, except using `diesel` as the SQL ORM instead of `sea-orm`
-default-diesel = ["default-common", "db-diesel-postgres-pool-async"]
+default = ["open-api", "jwt-ietf", "cli", "otel"]
 
 http = ["dep:axum", "dep:axum-extra", "dep:tower", "dep:tower-http", "dep:http-body-util", "dep:mime"]
 open-api = ["http", "dep:aide", "dep:schemars"]

--- a/book/examples/app-context/Cargo.toml
+++ b/book/examples/app-context/Cargo.toml
@@ -12,6 +12,6 @@ anyhow = { workspace = true }
 sea-orm = { workspace = true }
 
 [dev-dependencies]
-roadster = { path = "../../..", features = ["testing-mocks"] }
+roadster = { path = "../../..", features = ["db-sea-orm", "testing-mocks"] }
 sea-orm = { workspace = true, features = ["mock"] }
 tokio = { workspace = true, features = ["test-util"] }

--- a/book/examples/database-diesel/Cargo.toml
+++ b/book/examples/database-diesel/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-roadster = { path = "../../..", default-features = false, features = ["default-diesel"] }
+roadster = { path = "../../..", features = ["db-diesel-postgres-pool-async"] }
 diesel_migrations = { workspace = true }
 clap = { workspace = true }
 async-trait = { workspace = true }

--- a/book/examples/database/Cargo.toml
+++ b/book/examples/database/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-roadster = { path = "../../.." }
+roadster = { path = "../../..", features = ["db-sea-orm"] }
 sea-orm = { workspace = true }
 sea-orm-migration = { workspace = true }
 clap = { workspace = true }

--- a/examples/diesel/Cargo.toml
+++ b/examples/diesel/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-roadster = { version = "0.8.0-rc.3", path = "../..", default-features = false, features = ["default-diesel"] }
+roadster = { version = "0.8.0-rc.3", path = "../..", features = ["db-diesel-postgres-pool-async"] }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 anyhow = { workspace = true }

--- a/examples/full/Cargo.toml
+++ b/examples/full/Cargo.toml
@@ -11,7 +11,7 @@ default = ["grpc"]
 grpc = ["roadster/grpc", "dep:tonic", "dep:tonic-reflection", "dep:prost"]
 
 [dependencies]
-roadster = { version = "0.8.0-rc.3", path = "../..", features = ["email-smtp", "email-sendgrid", "config-yml", "otel-grpc"] }
+roadster = { version = "0.8.0-rc.3", path = "../..", features = ["worker-sidekiq", "db-sea-orm", "email-smtp", "email-sendgrid", "config-yml", "otel-grpc"] }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
Updates the `default` feature to remove sea-orm. Roadster no longer suggests a particular DB solution as the default. Instead, consumers should enable the `db-sea-orm` or `db-diesel-*` feature depending on the preferred solution.

Also updates the `default-common` feature to remove the sidekiq feature. Roadster no longer suggests a particular worker backend solution as the default. Instead, consumers should enable the `worker-sidekiq` or `worker-pg` feature depending on the preferred solution.

This PR also removes the `default-diesel` feature.