### PR TITLE
fix!: Add default worker retry config values

### DIFF
--- a/src/config/service/worker/default.toml
+++ b/src/config/service/worker/default.toml
@@ -2,9 +2,14 @@
 balance-strategy = "round-robin"
 
 [service.worker.worker-config]
-max-retries = 25
 timeout = true
 max-duration = 60000
+# Retry config
+max-retries = 25
+delay = 1000
+delay-offset = 10000
+max-delay = 86400000 # 24 hours
+backoff-strategy = "exponential"
 
 [service.worker.worker-config.pg]
 success-action = "delete"


### PR DESCRIPTION
Currently, workers will not retry by default even though the default retry config has `max-retries = 25`. This is because there is no retry strategy nor delay provided.

This PR adds sensible defaults for the retry config. This is maybe technically a breaking change, but it can also be considered a bug fix because we want workers to retry by default with the given `max-retries = 25` default.

This PR also fixes the exponential backoff delay calculation -- before, it would always be 0 if the delay config was < 1000 and always 1 second if the delay config was >= 1000 and < 2000.

This PR also fixes the delay calcuations to use `saturating_*` methods to avoid overflows.

Closes https://github.com/roadster-rs/roadster/issues/891