### PR TITLE
feat!: Allow `RunCommand` trait to return custom errors

### DIFF
--- a/book/examples/cli/src/cli.rs
+++ b/book/examples/cli/src/cli.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use clap::{Parser, Subcommand};
 use roadster::api::cli::{CliState, RunCommand};
 use roadster::app::context::AppContext;
-use roadster::error::RoadsterResult;
+use std::convert::Infallible;
 use tracing::info;
 
 /// CLI example: Commands specific to managing the `cli-example` app are provided in the CLI
@@ -18,8 +18,10 @@ pub struct AppCli {
 
 #[async_trait]
 impl RunCommand<App, AppContext> for AppCli {
+    type Error = Infallible;
+
     #[allow(clippy::disallowed_types)]
-    async fn run(&self, prepared_app: &CliState<App, AppContext>) -> RoadsterResult<bool> {
+    async fn run(&self, prepared_app: &CliState<App, AppContext>) -> Result<bool, Self::Error> {
         if let Some(command) = self.command.as_ref() {
             command.run(prepared_app).await
         } else {
@@ -39,7 +41,9 @@ pub enum AppCommand {
 
 #[async_trait]
 impl RunCommand<App, AppContext> for AppCommand {
-    async fn run(&self, _prepared_app: &CliState<App, AppContext>) -> RoadsterResult<bool> {
+    type Error = Infallible;
+
+    async fn run(&self, _prepared_app: &CliState<App, AppContext>) -> Result<bool, Self::Error> {
         match self {
             AppCommand::HelloWorld => {
                 info!("Hello, world!");

--- a/book/examples/database-diesel/src/cli.rs
+++ b/book/examples/database-diesel/src/cli.rs
@@ -3,14 +3,16 @@ use async_trait::async_trait;
 use clap::Parser;
 use roadster::api::cli::{CliState, RunCommand};
 use roadster::app::context::AppContext;
-use roadster::error::RoadsterResult;
+use std::convert::Infallible;
 
 #[derive(Parser)]
 pub struct Cli;
 
 #[async_trait]
 impl RunCommand<MyApp, AppContext> for Cli {
-    async fn run(&self, _prepared_app: &CliState<MyApp, AppContext>) -> RoadsterResult<bool> {
+    type Error = Infallible;
+
+    async fn run(&self, _prepared_app: &CliState<MyApp, AppContext>) -> Result<bool, Self::Error> {
         todo!()
     }
 }

--- a/book/examples/database/src/cli.rs
+++ b/book/examples/database/src/cli.rs
@@ -2,15 +2,17 @@ use crate::app::MyApp;
 use clap::Parser;
 use roadster::api::cli::{CliState, RunCommand};
 use roadster::app::context::AppContext;
-use roadster::error::RoadsterResult;
 use sea_orm::prelude::async_trait::async_trait;
+use std::convert::Infallible;
 
 #[derive(Parser)]
 pub struct Cli;
 
 #[async_trait]
 impl RunCommand<MyApp, AppContext> for Cli {
-    async fn run(&self, _prepared_app: &CliState<MyApp, AppContext>) -> RoadsterResult<bool> {
+    type Error = Infallible;
+
+    async fn run(&self, _prepared_app: &CliState<MyApp, AppContext>) -> Result<bool, Self::Error> {
         todo!()
     }
 }

--- a/examples/app-builder/src/api/cli/mod.rs
+++ b/examples/app-builder/src/api/cli/mod.rs
@@ -3,7 +3,7 @@ use crate::app_state::AppState;
 use async_trait::async_trait;
 use clap::{Parser, Subcommand};
 use roadster::api::cli::{CliState, RunCommand};
-use roadster::error::RoadsterResult;
+use std::convert::Infallible;
 
 /// App builder example: Commands specific to managing the `app_builder` example app are provided in
 /// the CLI as well. Subcommands not listed under the `roadster` subcommand are specific to
@@ -18,8 +18,10 @@ pub struct AppCli {
 
 #[async_trait]
 impl RunCommand<App, AppState> for AppCli {
+    type Error = Infallible;
+
     #[allow(clippy::disallowed_types)]
-    async fn run(&self, prepared_app: &CliState<App, AppState>) -> RoadsterResult<bool> {
+    async fn run(&self, prepared_app: &CliState<App, AppState>) -> Result<bool, Self::Error> {
         if let Some(command) = self.command.as_ref() {
             command.run(prepared_app).await
         } else {
@@ -36,7 +38,9 @@ pub enum AppCommand {}
 
 #[async_trait]
 impl RunCommand<App, AppState> for AppCommand {
-    async fn run(&self, _prepared_app: &CliState<App, AppState>) -> RoadsterResult<bool> {
+    type Error = Infallible;
+
+    async fn run(&self, _prepared_app: &CliState<App, AppState>) -> Result<bool, Self::Error> {
         Ok(false)
     }
 }

--- a/examples/diesel/src/cli/mod.rs
+++ b/examples/diesel/src/cli/mod.rs
@@ -3,7 +3,7 @@ use crate::app_state::AppState;
 use async_trait::async_trait;
 use clap::{Parser, Subcommand};
 use roadster::api::cli::{CliState, RunCommand};
-use roadster::error::RoadsterResult;
+use std::convert::Infallible;
 
 /// Full Example: Commands specific to managing the `full` app are provided in the CLI
 /// as well. Subcommands not listed under the `roadster` subcommand are specific to `full`.
@@ -17,8 +17,10 @@ pub struct AppCli {
 
 #[async_trait]
 impl RunCommand<App, AppState> for AppCli {
+    type Error = Infallible;
+
     #[allow(clippy::disallowed_types)]
-    async fn run(&self, prepared_app: &CliState<App, AppState>) -> RoadsterResult<bool> {
+    async fn run(&self, prepared_app: &CliState<App, AppState>) -> Result<bool, Self::Error> {
         if let Some(command) = self.command.as_ref() {
             command.run(prepared_app).await
         } else {
@@ -35,7 +37,9 @@ pub enum AppCommand {}
 
 #[async_trait]
 impl RunCommand<App, AppState> for AppCommand {
-    async fn run(&self, _prepared_app: &CliState<App, AppState>) -> RoadsterResult<bool> {
+    type Error = Infallible;
+
+    async fn run(&self, _prepared_app: &CliState<App, AppState>) -> Result<bool, Self::Error> {
         Ok(false)
     }
 }

--- a/examples/full/src/cli/mod.rs
+++ b/examples/full/src/cli/mod.rs
@@ -3,7 +3,7 @@ use crate::app_state::AppState;
 use async_trait::async_trait;
 use clap::{Parser, Subcommand};
 use roadster::api::cli::{CliState, RunCommand};
-use roadster::error::RoadsterResult;
+use std::convert::Infallible;
 
 /// Full Example: Commands specific to managing the `full` app are provided in the CLI
 /// as well. Subcommands not listed under the `roadster` subcommand are specific to `full`.
@@ -17,8 +17,10 @@ pub struct AppCli {
 
 #[async_trait]
 impl RunCommand<App, AppState> for AppCli {
+    type Error = Infallible;
+
     #[allow(clippy::disallowed_types)]
-    async fn run(&self, prepared_app: &CliState<App, AppState>) -> RoadsterResult<bool> {
+    async fn run(&self, prepared_app: &CliState<App, AppState>) -> Result<bool, Self::Error> {
         if let Some(command) = self.command.as_ref() {
             command.run(prepared_app).await
         } else {
@@ -35,7 +37,9 @@ pub enum AppCommand {}
 
 #[async_trait]
 impl RunCommand<App, AppState> for AppCommand {
-    async fn run(&self, _prepared_app: &CliState<App, AppState>) -> RoadsterResult<bool> {
+    type Error = Infallible;
+
+    async fn run(&self, _prepared_app: &CliState<App, AppState>) -> Result<bool, Self::Error> {
         Ok(false)
     }
 }

--- a/src/util/empty.rs
+++ b/src/util/empty.rs
@@ -14,10 +14,11 @@ where
     S: Clone + Send + Sync + 'static,
     crate::app::context::AppContext: axum_core::extract::FromRef<S>,
 {
+    type Error = std::convert::Infallible;
     async fn run(
         &self,
         _prepared_app: &crate::api::cli::CliState<crate::app::RoadsterApp<S, Empty>, S>,
-    ) -> crate::error::RoadsterResult<bool> {
+    ) -> Result<bool, Self::Error> {
         Ok(false)
     }
 }


### PR DESCRIPTION
Add `Error` associated type to the `RunCommand` trait to allow consumers to return a custom error from their `RunCommand` implementations.

Relates to https://github.com/roadster-rs/roadster/issues/922