### PR TITLE
feat!: Allow `HealthCheck` trait to return custom errors

### DIFF
--- a/book/examples/app-context/src/app.rs
+++ b/book/examples/app-context/src/app.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use axum::extract::FromRef;
 use roadster::app::RoadsterApp;
 use roadster::app::context::{AppContext, AppContextWeak};
-use roadster::error::RoadsterResult;
 use roadster::health::check::{CheckResponse, HealthCheck, Status};
 use std::time::Duration;
 
@@ -17,6 +16,8 @@ pub struct ExampleHealthCheck {
 
 #[async_trait]
 impl HealthCheck for ExampleHealthCheck {
+    type Error = roadster::error::Error;
+
     fn name(&self) -> String {
         "example".to_string()
     }
@@ -25,7 +26,7 @@ impl HealthCheck for ExampleHealthCheck {
         true
     }
 
-    async fn check(&self) -> RoadsterResult<CheckResponse> {
+    async fn check(&self) -> Result<CheckResponse, Self::Error> {
         // Upgrade the `AppContext` in order to use it
         let _context = self
             .context

--- a/book/examples/health-check/src/example_check.rs
+++ b/book/examples/health-check/src/example_check.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use roadster::app::context::{AppContext, AppContextWeak};
-use roadster::error::RoadsterResult;
 use roadster::health::check::{CheckResponse, HealthCheck, Status};
+use std::convert::Infallible;
 use std::time::Duration;
 
 pub struct ExampleCheck {
@@ -18,6 +18,8 @@ impl ExampleCheck {
 
 #[async_trait]
 impl HealthCheck for ExampleCheck {
+    type Error = Infallible;
+
     fn name(&self) -> String {
         "example".to_owned()
     }
@@ -38,7 +40,7 @@ impl HealthCheck for ExampleCheck {
         }
     }
 
-    async fn check(&self) -> RoadsterResult<CheckResponse> {
+    async fn check(&self) -> Result<CheckResponse, Self::Error> {
         Ok(CheckResponse::builder()
             .status(Status::Ok)
             .latency(Duration::from_secs(0))

--- a/examples/app-builder/src/health/check/example.rs
+++ b/examples/app-builder/src/health/check/example.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use roadster::error::RoadsterResult;
 use roadster::health::check::{CheckResponse, HealthCheck, Status};
+use std::convert::Infallible;
 use std::time::Duration;
 
 pub struct ExampleHealthCheck {
@@ -17,6 +18,8 @@ impl ExampleHealthCheck {
 
 #[async_trait]
 impl HealthCheck for ExampleHealthCheck {
+    type Error = Infallible;
+
     fn name(&self) -> String {
         self.name.clone()
     }
@@ -25,7 +28,7 @@ impl HealthCheck for ExampleHealthCheck {
         true
     }
 
-    async fn check(&self) -> RoadsterResult<CheckResponse> {
+    async fn check(&self) -> Result<CheckResponse, Self::Error> {
         Ok(CheckResponse::builder()
             .status(Status::Ok)
             .latency(Duration::from_secs(0))

--- a/examples/full/src/health/example.rs
+++ b/examples/full/src/health/example.rs
@@ -2,6 +2,7 @@ use crate::app_state::{AppState, AppStateWeak};
 use async_trait::async_trait;
 use roadster::error::RoadsterResult;
 use roadster::health::check::{CheckResponse, ErrorData, HealthCheck, Status};
+use std::convert::Infallible;
 use std::time::Duration;
 use tracing::error;
 
@@ -33,6 +34,8 @@ impl ExampleHealthCheck {
 
 #[async_trait]
 impl HealthCheck for ExampleHealthCheck {
+    type Error = Infallible;
+
     fn name(&self) -> String {
         "example".to_string()
     }
@@ -52,7 +55,7 @@ impl HealthCheck for ExampleHealthCheck {
             .unwrap_or(state.app_context.config().health_check.default_enable)
     }
 
-    async fn check(&self) -> RoadsterResult<CheckResponse> {
+    async fn check(&self) -> Result<CheckResponse, Self::Error> {
         let state = self.state.upgrade();
 
         let response = match state {

--- a/src/api/core/health.rs
+++ b/src/api/core/health.rs
@@ -46,7 +46,7 @@ where
 
 #[instrument(skip_all)]
 pub(crate) async fn health_check_with_checks<S>(
-    checks: Vec<Arc<dyn HealthCheck>>,
+    checks: Vec<Arc<dyn HealthCheck<Error = crate::error::Error>>>,
     duration: Option<Duration>,
 ) -> RoadsterResult<HeathCheckResponse>
 where
@@ -105,7 +105,7 @@ where
 }
 
 async fn run_check(
-    check: Arc<dyn HealthCheck>,
+    check: Arc<dyn HealthCheck<Error = crate::error::Error>>,
     duration: Option<Duration>,
 ) -> RoadsterResult<CheckResponse> {
     if let Some(duration) = duration {

--- a/src/app/context/mod.rs
+++ b/src/app/context/mod.rs
@@ -357,7 +357,7 @@ impl AppContext {
 
     /// Returns the [`HealthCheck`]s that were registered in the [`HealthCheckRegistry`], or
     /// an empty [`Vec`] if no [`HealthCheck`]s were registered.
-    pub fn health_checks(&self) -> Vec<Arc<dyn HealthCheck>> {
+    pub fn health_checks(&self) -> Vec<Arc<dyn HealthCheck<Error = crate::error::Error>>> {
         self.inner.health_checks()
     }
 
@@ -672,8 +672,8 @@ impl Provide<AppMetadata> for AppContext {
     }
 }
 
-impl Provide<Vec<Arc<dyn HealthCheck>>> for AppContext {
-    fn provide(&self) -> Vec<Arc<dyn HealthCheck>> {
+impl Provide<Vec<Arc<dyn HealthCheck<Error = crate::error::Error>>>> for AppContext {
+    fn provide(&self) -> Vec<Arc<dyn HealthCheck<Error = crate::error::Error>>> {
         self.health_checks()
     }
 }
@@ -1233,7 +1233,7 @@ impl AppContextInner {
         &self.metadata
     }
 
-    fn health_checks(&self) -> Vec<Arc<dyn HealthCheck>> {
+    fn health_checks(&self) -> Vec<Arc<dyn HealthCheck<Error = crate::error::Error>>> {
         self.health_checks
             .get()
             .map(|health_checks| health_checks.checks())

--- a/src/health/check/db/diesel_mysql_async.rs
+++ b/src/health/check/db/diesel_mysql_async.rs
@@ -1,6 +1,5 @@
 use crate::api::core::health::db_diesel_health_mysql_async;
 use crate::app::context::{AppContext, AppContextWeak};
-use crate::error::RoadsterResult;
 use crate::health::check::{CheckResponse, HealthCheck, missing_context_response};
 use async_trait::async_trait;
 use tracing::instrument;
@@ -11,6 +10,8 @@ pub struct DbDieselMysqlAsyncHealthCheck {
 
 #[async_trait]
 impl HealthCheck for DbDieselMysqlAsyncHealthCheck {
+    type Error = crate::error::Error;
+
     fn name(&self) -> String {
         "db-diesel-mysql-async".to_string()
     }
@@ -23,7 +24,7 @@ impl HealthCheck for DbDieselMysqlAsyncHealthCheck {
     }
 
     #[instrument(skip_all)]
-    async fn check(&self) -> RoadsterResult<CheckResponse> {
+    async fn check(&self) -> Result<CheckResponse, Self::Error> {
         let context = self.context.upgrade();
         let response = match context {
             Some(context) => db_diesel_health_mysql_async(&context, None).await,

--- a/src/health/check/db/diesel_pg_async.rs
+++ b/src/health/check/db/diesel_pg_async.rs
@@ -1,6 +1,5 @@
 use crate::api::core::health::db_diesel_health_pg_async;
 use crate::app::context::{AppContext, AppContextWeak};
-use crate::error::RoadsterResult;
 use crate::health::check::{CheckResponse, HealthCheck, missing_context_response};
 use async_trait::async_trait;
 use tracing::instrument;
@@ -11,6 +10,8 @@ pub struct DbDieselPgAsyncHealthCheck {
 
 #[async_trait]
 impl HealthCheck for DbDieselPgAsyncHealthCheck {
+    type Error = crate::error::Error;
+
     fn name(&self) -> String {
         "db-diesel-postgres-async".to_string()
     }
@@ -23,7 +24,7 @@ impl HealthCheck for DbDieselPgAsyncHealthCheck {
     }
 
     #[instrument(skip_all)]
-    async fn check(&self) -> RoadsterResult<CheckResponse> {
+    async fn check(&self) -> Result<CheckResponse, Self::Error> {
         let context = self.context.upgrade();
         let response = match context {
             Some(context) => db_diesel_health_pg_async(&context, None).await,

--- a/src/health/check/db/sea_orm.rs
+++ b/src/health/check/db/sea_orm.rs
@@ -1,6 +1,5 @@
 use crate::api::core::health::db_sea_orm_health;
 use crate::app::context::{AppContext, AppContextWeak};
-use crate::error::RoadsterResult;
 use crate::health::check::{CheckResponse, HealthCheck, missing_context_response};
 use async_trait::async_trait;
 use tracing::instrument;
@@ -11,6 +10,8 @@ pub struct DbSeaOrmHealthCheck {
 
 #[async_trait]
 impl HealthCheck for DbSeaOrmHealthCheck {
+    type Error = crate::error::Error;
+
     fn name(&self) -> String {
         "db-sea-orm".to_string()
     }
@@ -23,7 +24,7 @@ impl HealthCheck for DbSeaOrmHealthCheck {
     }
 
     #[instrument(skip_all)]
-    async fn check(&self) -> RoadsterResult<CheckResponse> {
+    async fn check(&self) -> Result<CheckResponse, Self::Error> {
         let context = self.context.upgrade();
         let response = match context {
             Some(context) => db_sea_orm_health(&context, None).await,

--- a/src/health/check/default.rs
+++ b/src/health/check/default.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 pub fn default_health_checks(
     #[allow(unused_variables)] context: &AppContext,
-) -> BTreeMap<String, Arc<dyn HealthCheck>> {
-    let health_checks: Vec<Arc<dyn HealthCheck>> = vec![
+) -> BTreeMap<String, Arc<dyn HealthCheck<Error = crate::error::Error>>> {
+    let health_checks: Vec<Arc<dyn HealthCheck<Error = crate::error::Error>>> = vec![
         #[cfg(feature = "db-sea-orm")]
         Arc::new(DbSeaOrmHealthCheck {
             context: context.downgrade(),

--- a/src/health/check/email/smtp.rs
+++ b/src/health/check/email/smtp.rs
@@ -1,6 +1,5 @@
 use crate::api::core::health::smtp_health;
 use crate::app::context::{AppContext, AppContextWeak};
-use crate::error::RoadsterResult;
 use crate::health::check::{CheckResponse, HealthCheck, missing_context_response};
 use async_trait::async_trait;
 use tracing::instrument;
@@ -11,6 +10,8 @@ pub struct SmtpHealthCheck {
 
 #[async_trait]
 impl HealthCheck for SmtpHealthCheck {
+    type Error = crate::error::Error;
+
     fn name(&self) -> String {
         "smtp".to_string()
     }
@@ -23,7 +24,7 @@ impl HealthCheck for SmtpHealthCheck {
     }
 
     #[instrument(skip_all)]
-    async fn check(&self) -> RoadsterResult<CheckResponse> {
+    async fn check(&self) -> Result<CheckResponse, Self::Error> {
         let context = self.context.upgrade();
         let response = match context {
             Some(context) => smtp_health(&context, None).await,

--- a/src/health/check/worker/pg/mod.rs
+++ b/src/health/check/worker/pg/mod.rs
@@ -1,6 +1,5 @@
 use crate::api::core::health::worker_pg_health;
 use crate::app::context::{AppContext, AppContextWeak};
-use crate::error::RoadsterResult;
 use crate::health::check::{CheckResponse, HealthCheck, missing_context_response};
 use async_trait::async_trait;
 use tracing::instrument;
@@ -11,6 +10,8 @@ pub struct PgWorkerHealthCheck {
 
 #[async_trait]
 impl HealthCheck for PgWorkerHealthCheck {
+    type Error = crate::error::Error;
+
     fn name(&self) -> String {
         "worker-pg".to_string()
     }
@@ -23,7 +24,7 @@ impl HealthCheck for PgWorkerHealthCheck {
     }
 
     #[instrument(skip_all)]
-    async fn check(&self) -> RoadsterResult<CheckResponse> {
+    async fn check(&self) -> Result<CheckResponse, Self::Error> {
         let context = self.context.upgrade();
         let response = match context {
             Some(context) => worker_pg_health(&context, None).await,

--- a/src/health/check/worker/sidekiq/sidekiq_enqueue.rs
+++ b/src/health/check/worker/sidekiq/sidekiq_enqueue.rs
@@ -1,6 +1,5 @@
 use crate::api::core::health::redis_health;
 use crate::app::context::{AppContext, AppContextWeak};
-use crate::error::RoadsterResult;
 use crate::health::check::{CheckResponse, HealthCheck, missing_context_response};
 use async_trait::async_trait;
 use tracing::instrument;
@@ -11,6 +10,8 @@ pub struct SidekiqEnqueueHealthCheck {
 
 #[async_trait]
 impl HealthCheck for SidekiqEnqueueHealthCheck {
+    type Error = crate::error::Error;
+
     fn name(&self) -> String {
         "sidekiq-enqueue".to_string()
     }
@@ -23,7 +24,7 @@ impl HealthCheck for SidekiqEnqueueHealthCheck {
     }
 
     #[instrument(skip_all)]
-    async fn check(&self) -> RoadsterResult<CheckResponse> {
+    async fn check(&self) -> Result<CheckResponse, Self::Error> {
         let context = self.context.upgrade();
         let response = match context {
             Some(context) => redis_health(context.redis_enqueue(), None).await,

--- a/src/health/check/worker/sidekiq/sidekiq_fetch.rs
+++ b/src/health/check/worker/sidekiq/sidekiq_fetch.rs
@@ -1,6 +1,5 @@
 use crate::api::core::health::redis_health;
 use crate::app::context::{AppContext, AppContextWeak};
-use crate::error::RoadsterResult;
 use crate::health::check::{CheckResponse, HealthCheck, missing_context_response};
 use async_trait::async_trait;
 use tracing::instrument;
@@ -11,6 +10,8 @@ pub struct SidekiqFetchHealthCheck {
 
 #[async_trait]
 impl HealthCheck for SidekiqFetchHealthCheck {
+    type Error = crate::error::Error;
+
     fn name(&self) -> String {
         "sidekiq-fetch".to_string()
     }
@@ -23,7 +24,7 @@ impl HealthCheck for SidekiqFetchHealthCheck {
     }
 
     #[instrument(skip_all)]
-    async fn check(&self) -> RoadsterResult<CheckResponse> {
+    async fn check(&self) -> Result<CheckResponse, Self::Error> {
         let context = self.context.upgrade();
         let response = match context {
             Some(context) => {

--- a/src/service/runner.rs
+++ b/src/service/runner.rs
@@ -15,7 +15,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument, warn};
 
 #[instrument(skip_all)]
-pub(crate) async fn health_checks(checks: Vec<Arc<dyn HealthCheck>>) -> RoadsterResult<()> {
+pub(crate) async fn health_checks(
+    checks: Vec<Arc<dyn HealthCheck<Error = crate::error::Error>>>,
+) -> RoadsterResult<()> {
     let duration = Duration::from_secs(60);
     let response = health_check_with_checks(checks, Some(duration)).await?;
 


### PR DESCRIPTION
Add `Error` associated type to the `HealthCheck` trait to allow consumers to return a custom error from their `HealthCheck` implementations.

Relates to https://github.com/roadster-rs/roadster/issues/922