### PR TITLE
feat!: Allow `Migrator` trait to return custom errors

### DIFF
--- a/book/examples/database-diesel/src/app.rs
+++ b/book/examples/database-diesel/src/app.rs
@@ -3,7 +3,7 @@ use diesel_migrations::{EmbeddedMigrations, embed_migrations};
 use roadster::app::App;
 use roadster::app::context::AppContext;
 use roadster::config::AppConfig;
-use roadster::db::migration::diesel::DieselMigrator;
+use roadster::db::migration::registry::MigratorRegistry;
 
 pub struct MyApp;
 
@@ -26,10 +26,10 @@ impl App<AppContext> for MyApp {
 
     fn migrators(
         &self,
+        registry: &mut MigratorRegistry<AppContext>,
         _state: &AppContext,
-    ) -> Result<Vec<Box<dyn roadster::db::migration::Migrator<AppContext>>>, Self::Error> {
-        Ok(vec![Box::new(
-            DieselMigrator::<roadster::db::DieselPgConn>::new(MIGRATIONS),
-        )])
+    ) -> Result<(), Self::Error> {
+        registry.register_diesel_migrator::<roadster::db::DieselPgConn>(MIGRATIONS)?;
+        Ok(())
     }
 }

--- a/book/examples/database/src/app.rs
+++ b/book/examples/database/src/app.rs
@@ -2,7 +2,7 @@ use crate::migrator::Migrator;
 use roadster::app::App;
 use roadster::app::context::AppContext;
 use roadster::config::AppConfig;
-use roadster::db::migration::sea_orm::SeaOrmMigrator;
+use roadster::db::migration::registry::MigratorRegistry;
 use sea_orm::prelude::async_trait::async_trait;
 
 pub struct MyApp;
@@ -24,8 +24,10 @@ impl App<AppContext> for MyApp {
 
     fn migrators(
         &self,
+        registry: &mut MigratorRegistry<AppContext>,
         _state: &AppContext,
-    ) -> Result<Vec<Box<dyn roadster::db::migration::Migrator<AppContext>>>, Self::Error> {
-        Ok(vec![Box::new(SeaOrmMigrator::new(Migrator))])
+    ) -> Result<(), Self::Error> {
+        registry.register_sea_orm_migrator(Migrator)?;
+        Ok(())
     }
 }

--- a/examples/full/src/app.rs
+++ b/examples/full/src/app.rs
@@ -14,7 +14,7 @@ use roadster::app::App as RoadsterApp;
 use roadster::app::context::AppContext;
 use roadster::app::metadata::AppMetadata;
 use roadster::config::AppConfig;
-use roadster::db::migration::sea_orm::SeaOrmMigrator;
+use roadster::db::migration::registry::MigratorRegistry;
 use roadster::health::check::registry::HealthCheckRegistry;
 use roadster::lifecycle::registry::LifecycleHandlerRegistry;
 use roadster::service::function::service::FunctionService;
@@ -57,9 +57,10 @@ impl RoadsterApp<AppState> for App {
 
     fn migrators(
         &self,
+        registry: &mut MigratorRegistry<AppState>,
         _state: &AppState,
-    ) -> Result<Vec<Box<dyn roadster::db::migration::Migrator<AppState>>>, Self::Error> {
-        Ok(vec![Box::new(SeaOrmMigrator::new(Migrator))])
+    ) -> Result<(), Self::Error> {
+        registry.register_sea_orm_migrator(Migrator)
     }
 
     async fn health_checks(

--- a/src/api/cli/mod.rs
+++ b/src/api/cli/mod.rs
@@ -3,6 +3,8 @@ use crate::app::App;
 #[cfg(test)]
 use crate::app::MockApp;
 use crate::app::context::AppContext;
+#[cfg(feature = "db-sql")]
+use crate::db::migration::registry::MigratorRegistry;
 use crate::error::RoadsterResult;
 use crate::service::registry::ServiceRegistry;
 use async_trait::async_trait;
@@ -24,7 +26,7 @@ where
     pub app: A,
     pub state: S,
     #[cfg(feature = "db-sql")]
-    pub migrators: Vec<Box<dyn crate::db::migration::Migrator<S>>>,
+    pub migrator_registry: MigratorRegistry<S>,
     pub service_registry: ServiceRegistry<S>,
 }
 
@@ -265,7 +267,7 @@ mod tests {
             app_cli,
             app,
             #[cfg(feature = "db-sql")]
-            migrators: Default::default(),
+            migrator_registry: MigratorRegistry::new(),
             service_registry: ServiceRegistry::new(&context),
             state: context,
         };

--- a/src/api/cli/roadster/migrate.rs
+++ b/src/api/cli/roadster/migrate.rs
@@ -98,7 +98,7 @@ where
     A: App<S>,
 {
     let mut total_steps_run = 0;
-    for migrator in cli.migrators.iter() {
+    for migrator in cli.migrator_registry.migrators().iter() {
         let remaining_steps = args
             .steps
             .map(|steps| steps.saturating_sub(total_steps_run));
@@ -126,7 +126,7 @@ where
     A: App<S>,
 {
     let mut total_steps_run = 0;
-    for migrator in cli.migrators.iter().rev() {
+    for migrator in cli.migrator_registry.migrators().iter().rev() {
         let remaining_steps = args
             .steps
             .map(|steps| steps.saturating_sub(total_steps_run));
@@ -153,7 +153,7 @@ where
     A: App<S>,
 {
     let mut migrations: Vec<MigrationInfo> = Vec::new();
-    for migrator in cli.migrators.iter() {
+    for migrator in cli.migrator_registry.migrators().iter() {
         migrations.extend(migrator.status(&cli.state).await?);
     }
     let migrations = migrations

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -36,7 +36,7 @@ use crate::app::metadata::AppMetadata;
 use crate::config::AppConfig;
 use crate::config::environment::Environment;
 #[cfg(feature = "db-sql")]
-use crate::db::migration::Migrator;
+use crate::db::migration::registry::MigratorRegistry;
 use crate::health::check::registry::HealthCheckRegistry;
 use crate::lifecycle::registry::LifecycleHandlerRegistry;
 use crate::service::registry::ServiceRegistry;
@@ -206,15 +206,13 @@ where
     /// See the following for more details regarding [`FromRef`]: <https://docs.rs/axum/0.7.5/axum/extract/trait.FromRef.html>
     async fn provide_state(&self, context: AppContext) -> Result<S, Self::Error>;
 
-    /// Note: SeaORM and Diesel migrations expect all of the applied migrations to be available
-    /// to the provided migrator, so multiple SeaORM or Diesel migrators should not be provided
-    /// via this method.
     #[cfg(feature = "db-sql")]
     fn migrators(
         &self,
+        #[allow(unused_variables)] registry: &mut MigratorRegistry<S>,
         #[allow(unused_variables)] state: &S,
-    ) -> Result<Vec<Box<dyn Migrator<S>>>, Self::Error> {
-        Ok(Default::default())
+    ) -> Result<(), Self::Error> {
+        Ok(())
     }
 
     async fn lifecycle_handlers(

--- a/src/app/run.rs
+++ b/src/app/run.rs
@@ -41,7 +41,7 @@ where
                 app: prepared.app,
                 state: prepared.state,
                 #[cfg(feature = "db-sql")]
-                migrators: prepared.migrators,
+                migrator_registry: prepared.migrator_registry,
                 service_registry: prepared.service_registry,
             };
             if crate::api::cli::handle_cli(&cli).await? {
@@ -51,7 +51,7 @@ where
                 app: cli.app,
                 state: cli.state,
                 #[cfg(feature = "db-sql")]
-                migrators: cli.migrators,
+                migrator_registry: cli.migrator_registry,
                 service_registry: cli.service_registry,
                 lifecycle_handler_registry: prepared.lifecycle_handler_registry,
             }
@@ -60,7 +60,7 @@ where
                 app: prepared.app,
                 state: prepared.state,
                 #[cfg(feature = "db-sql")]
-                migrators: prepared.migrators,
+                migrator_registry: prepared.migrator_registry,
                 service_registry: prepared.service_registry,
                 lifecycle_handler_registry: prepared.lifecycle_handler_registry,
             }
@@ -72,7 +72,7 @@ where
         app: prepared.app,
         state: prepared.state,
         #[cfg(feature = "db-sql")]
-        migrators: prepared.migrators,
+        migrator_registry: prepared.migrator_registry,
         service_registry: prepared.service_registry,
         lifecycle_handler_registry: prepared.lifecycle_handler_registry,
     };

--- a/src/app/test.rs
+++ b/src/app/test.rs
@@ -82,7 +82,7 @@ where
         app: prepared.app,
         state: prepared.state,
         #[cfg(feature = "db-sql")]
-        migrators: prepared.migrators,
+        migrator_registry: prepared.migrator_registry,
         service_registry: prepared.service_registry,
         lifecycle_handler_registry: prepared.lifecycle_handler_registry,
     };

--- a/src/db/migration/registry.rs
+++ b/src/db/migration/registry.rs
@@ -1,0 +1,234 @@
+use crate::app::context::AppContext;
+#[cfg(feature = "db-diesel")]
+use crate::db::migration::diesel::DieselMigrator;
+#[cfg(feature = "db-sea-orm")]
+use crate::db::migration::sea_orm::SeaOrmMigrator;
+use crate::db::migration::{DownArgs, MigrationInfo, Migrator, UpArgs};
+use crate::error::RoadsterResult;
+use async_trait::async_trait;
+use axum_core::extract::FromRef;
+#[cfg(feature = "db-diesel")]
+use diesel::Connection;
+#[cfg(feature = "db-diesel")]
+use diesel_migrations::MigrationHarness;
+use itertools::Itertools;
+use std::any::type_name;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum MigratorRegistryError {
+    /// The provided [`Migrator`] was already registered. Contains the
+    /// type name of the provided service.
+    #[error("The provided `Migrator` was already registered: `{0}`")]
+    AlreadyRegistered(&'static str),
+
+    #[error(transparent)]
+    Other(#[from] Box<dyn Send + Sync + std::error::Error>),
+}
+
+/// Registry of [`Migrator`]s that will be run to set up the database.
+pub struct MigratorRegistry<S>
+where
+    S: 'static + Send + Sync + Clone,
+    AppContext: FromRef<S>,
+{
+    migrators: BTreeMap<&'static str, Box<dyn Migrator<S, Error = crate::error::Error>>>,
+}
+
+impl<S> MigratorRegistry<S>
+where
+    S: 'static + Send + Sync + Clone,
+    AppContext: FromRef<S>,
+{
+    pub(crate) fn new() -> Self {
+        Self {
+            migrators: Default::default(),
+        }
+    }
+
+    /// Register a new [`Migrator`].
+    ///
+    /// Note: SeaORM and Diesel migrations expect all of the applied migrations to be available
+    /// to the provided migrator, so multiple SeaORM or Diesel migrators should not be provided
+    /// to this [`MigratorRegistry`].
+    pub fn register<M>(&mut self, migrator: M) -> RoadsterResult<()>
+    where
+        M: 'static + Migrator<S>,
+    {
+        self.register_wrapped(MigratorWrapper::new(migrator))
+    }
+
+    /// Register a new [`sea_orm_migration::MigratorTrait`].
+    ///
+    /// Note: SeaORM migrations expect all of the applied migrations to be available
+    /// to the provided migrator, so this method should only be called once.
+    #[cfg(feature = "db-sea-orm")]
+    pub fn register_sea_orm_migrator<M>(&mut self, migrator: M) -> RoadsterResult<()>
+    where
+        M: 'static + Send + Sync + sea_orm_migration::MigratorTrait,
+    {
+        self.register_wrapped(MigratorWrapper::new(SeaOrmMigrator::new(migrator)))
+    }
+
+    /// Register a new [`diesel::migration::MigrationSource`].
+    ///
+    /// Note: Diesel migrations expect all of the applied migrations to be available
+    /// to the provided migrator, so this method should only be called once.
+    #[cfg(feature = "db-diesel")]
+    pub fn register_diesel_migrator<C>(
+        &mut self,
+        migrator: impl 'static + Send + Sync + diesel::migration::MigrationSource<C::Backend>,
+    ) -> RoadsterResult<()>
+    where
+        C: 'static + Send + Connection + MigrationHarness<C::Backend>,
+    {
+        self.register_wrapped(MigratorWrapper::new(DieselMigrator::<C>::new(migrator)))
+    }
+
+    pub(crate) fn register_wrapped(&mut self, migrator: MigratorWrapper<S>) -> RoadsterResult<()> {
+        self.register_boxed(migrator.type_name, Box::new(migrator))
+    }
+
+    pub(crate) fn register_boxed(
+        &mut self,
+        type_name: &'static str,
+        migrator: Box<dyn Migrator<S, Error = crate::error::Error>>,
+    ) -> RoadsterResult<()> {
+        if self.migrators.insert(type_name, migrator).is_some() {
+            return Err(MigratorRegistryError::AlreadyRegistered(type_name).into());
+        }
+
+        Ok(())
+    }
+
+    pub fn migrators(&self) -> Vec<&dyn Migrator<S, Error = crate::error::Error>> {
+        self.migrators
+            .values()
+            .map(|migrator| migrator.as_ref())
+            .collect_vec()
+    }
+}
+
+type UpFn<S> = Box<
+    dyn Send
+        + Sync
+        + for<'a> Fn(
+            &'a S,
+            &'a UpArgs,
+        )
+            -> std::pin::Pin<Box<dyn 'a + Send + Future<Output = RoadsterResult<usize>>>>,
+>;
+
+type DownFn<S> = Box<
+    dyn Send
+        + Sync
+        + for<'a> Fn(
+            &'a S,
+            &'a DownArgs,
+        )
+            -> std::pin::Pin<Box<dyn 'a + Send + Future<Output = RoadsterResult<usize>>>>,
+>;
+
+type StatusFn<S> = Box<
+    dyn Send
+        + Sync
+        + for<'a> Fn(
+            &'a S,
+        ) -> std::pin::Pin<
+            Box<dyn 'a + Send + Future<Output = RoadsterResult<Vec<MigrationInfo>>>>,
+        >,
+>;
+
+pub(crate) struct MigratorWrapper<S>
+where
+    S: 'static + Send + Sync + Clone,
+    AppContext: FromRef<S>,
+{
+    pub(crate) type_name: &'static str,
+    up_fn: UpFn<S>,
+    down_fn: DownFn<S>,
+    status_fn: StatusFn<S>,
+}
+
+impl<S> MigratorWrapper<S>
+where
+    S: 'static + Send + Sync + Clone,
+    AppContext: FromRef<S>,
+{
+    pub(crate) fn new<M>(migrator: M) -> Self
+    where
+        M: 'static + Migrator<S>,
+    {
+        let type_name = type_name::<M>();
+        let migrator = Arc::new(migrator);
+        let up_fn: UpFn<S> = {
+            let migrator = migrator.clone();
+            Box::new(move |state, args| {
+                let migrator = migrator.clone();
+                Box::pin(async move {
+                    let result = migrator
+                        .up(state, args)
+                        .await
+                        .map_err(|err| MigratorRegistryError::Other(Box::new(err)))?;
+                    Ok(result)
+                })
+            })
+        };
+        let down_fn: DownFn<S> = {
+            let migrator = migrator.clone();
+            Box::new(move |state, args| {
+                let migrator = migrator.clone();
+                Box::pin(async move {
+                    let result = migrator
+                        .down(state, args)
+                        .await
+                        .map_err(|err| MigratorRegistryError::Other(Box::new(err)))?;
+                    Ok(result)
+                })
+            })
+        };
+        let status_fn: StatusFn<S> = {
+            let migrator = migrator.clone();
+            Box::new(move |state| {
+                let migrator = migrator.clone();
+                Box::pin(async move {
+                    let result = migrator
+                        .status(state)
+                        .await
+                        .map_err(|err| MigratorRegistryError::Other(Box::new(err)))?;
+                    Ok(result)
+                })
+            })
+        };
+        Self {
+            type_name,
+            up_fn,
+            down_fn,
+            status_fn,
+        }
+    }
+}
+
+#[async_trait]
+impl<S> Migrator<S> for MigratorWrapper<S>
+where
+    S: 'static + Send + Sync + Clone,
+    AppContext: FromRef<S>,
+{
+    type Error = crate::error::Error;
+
+    async fn up(&self, state: &S, args: &UpArgs) -> Result<usize, Self::Error> {
+        (self.up_fn)(state, args).await
+    }
+
+    async fn down(&self, state: &S, args: &DownArgs) -> Result<usize, Self::Error> {
+        (self.down_fn)(state, args).await
+    }
+
+    async fn status(&self, state: &S) -> Result<Vec<MigrationInfo>, Self::Error> {
+        (self.status_fn)(state).await
+    }
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -28,6 +28,8 @@ pub mod tracing;
 pub mod worker;
 
 use crate::app::context::extension::ExtensionRegistryError;
+#[cfg(feature = "db-sql")]
+use crate::db::migration::registry::MigratorRegistryError;
 use crate::error::api::ApiError;
 use crate::error::auth::AuthError;
 #[cfg(feature = "http")]
@@ -149,6 +151,10 @@ pub enum Error {
 
     #[error(transparent)]
     ExtensionRegistry(#[from] ExtensionRegistryError),
+
+    #[cfg(feature = "db-sql")]
+    #[error(transparent)]
+    MigratorRegistry(#[from] MigratorRegistryError),
 
     #[error(transparent)]
     Mutex(#[from] MutexError),

--- a/src/health/check/registry.rs
+++ b/src/health/check/registry.rs
@@ -102,7 +102,7 @@ impl HealthCheckWrapper {
                 let result = health_check
                     .check()
                     .await
-                    .map_err(|err| crate::error::other::OtherError::Other(Box::new(err)))?;
+                    .map_err(|err| HealthCheckRegistryError::Other(Box::new(err)))?;
                 Ok(result)
             })
         });

--- a/src/lifecycle/db/migration.rs
+++ b/src/lifecycle/db/migration.rs
@@ -50,7 +50,7 @@ where
         &self,
         prepared_app: &PreparedAppWithoutCli<A, S>,
     ) -> Result<(), Self::Error> {
-        for migrator in prepared_app.migrators.iter() {
+        for migrator in prepared_app.migrator_registry.migrators().iter() {
             migrator
                 .up(&prepared_app.state, &UpArgs::builder().build())
                 .await?;

--- a/src/lifecycle/registry.rs
+++ b/src/lifecycle/registry.rs
@@ -185,7 +185,7 @@ where
                     handler
                         .before_health_checks(prepared)
                         .await
-                        .map_err(|err| crate::error::other::OtherError::Other(Box::new(err)))?;
+                        .map_err(|err| LifecycleHandlerRegistryError::Other(Box::new(err)))?;
                     Ok(())
                 })
             })
@@ -198,7 +198,7 @@ where
                     handler
                         .before_services(prepared)
                         .await
-                        .map_err(|err| crate::error::other::OtherError::Other(Box::new(err)))?;
+                        .map_err(|err| LifecycleHandlerRegistryError::Other(Box::new(err)))?;
                     Ok(())
                 })
             })
@@ -211,7 +211,7 @@ where
                     handler
                         .on_shutdown(state)
                         .await
-                        .map_err(|err| crate::error::other::OtherError::Other(Box::new(err)))?;
+                        .map_err(|err| LifecycleHandlerRegistryError::Other(Box::new(err)))?;
                     Ok(())
                 })
             })

--- a/src/service/registry.rs
+++ b/src/service/registry.rs
@@ -1,6 +1,5 @@
 use crate::app::context::AppContext;
 use crate::error::RoadsterResult;
-use crate::error::other::OtherError;
 use crate::service::{Service, ServiceBuilder};
 use axum_core::extract::FromRef;
 use std::any::{Any, TypeId, type_name};
@@ -87,7 +86,7 @@ where
         let service = builder
             .build(&self.state)
             .await
-            .map_err(|err| crate::error::other::OtherError::Other(Box::new(err)))?;
+            .map_err(|err| ServiceRegistryError::Other(Box::new(err)))?;
 
         self.register_wrapped(ServiceWrapper::new(service))
     }
@@ -286,7 +285,7 @@ where
                     inner
                         .before_run(state)
                         .await
-                        .map_err(|err| OtherError::Other(Box::new(err)))?;
+                        .map_err(|err| ServiceRegistryError::Other(Box::new(err)))?;
                     Ok(())
                 })
             })
@@ -309,7 +308,7 @@ where
                     inner
                         .run(state, cancellation_token)
                         .await
-                        .map_err(|err| OtherError::Other(Box::new(err)))?;
+                        .map_err(|err| ServiceRegistryError::Other(Box::new(err)))?;
                     Ok(())
                 })
             })


### PR DESCRIPTION
Add `Error` associated type to the `Migrator` trait to allow consumers to return a custom error from their `Migrator` implementations.

Relates to https://github.com/roadster-rs/roadster/issues/922