### PR TITLE
chore!: Rearrange method params to put state as first param

### DIFF
--- a/book/examples/database-diesel/src/app.rs
+++ b/book/examples/database-diesel/src/app.rs
@@ -26,8 +26,8 @@ impl App<AppContext> for MyApp {
 
     fn migrators(
         &self,
-        registry: &mut MigratorRegistry<AppContext>,
         _state: &AppContext,
+        registry: &mut MigratorRegistry<AppContext>,
     ) -> Result<(), Self::Error> {
         registry.register_diesel_migrator::<roadster::db::DieselPgConn>(MIGRATIONS)?;
         Ok(())

--- a/book/examples/database/src/app.rs
+++ b/book/examples/database/src/app.rs
@@ -24,8 +24,8 @@ impl App<AppContext> for MyApp {
 
     fn migrators(
         &self,
-        registry: &mut MigratorRegistry<AppContext>,
         _state: &AppContext,
+        registry: &mut MigratorRegistry<AppContext>,
     ) -> Result<(), Self::Error> {
         registry.register_sea_orm_migrator(Migrator)?;
         Ok(())

--- a/book/examples/open-api/src/http/mod.rs
+++ b/book/examples/open-api/src/http/mod.rs
@@ -14,7 +14,7 @@ use tracing::instrument;
 const BASE: &str = "/api";
 
 pub fn http_service(state: &AppContext) -> HttpServiceBuilder<AppContext> {
-    HttpServiceBuilder::new(Some(BASE), state)
+    HttpServiceBuilder::new(state, Some(BASE))
         // Create your routes as an `ApiRouter` in order to include it in the OpenAPI schema.
         .api_router(
             ApiRouter::new()

--- a/book/examples/service/src/http/initializer.rs
+++ b/book/examples/service/src/http/initializer.rs
@@ -14,7 +14,7 @@ const BASE: &str = "/api";
 /// Set up the [`HttpServiceBuilder`]. This will then be registered with the
 /// [`roadster::service::registry::ServiceRegistry`].
 pub async fn http_service(state: &AppContext) -> RoadsterResult<HttpServiceBuilder<AppContext>> {
-    HttpServiceBuilder::new(Some(BASE), state)
+    HttpServiceBuilder::new(state, Some(BASE))
         .api_router(ApiRouter::new().api_route(
             &build_path(BASE, "/example_b"),
             get_with(example_b::example_b_get, example_b::example_b_get_docs),

--- a/book/examples/service/src/http/middleware.rs
+++ b/book/examples/service/src/http/middleware.rs
@@ -16,7 +16,7 @@ const BASE: &str = "/api";
 /// Set up the [`HttpServiceBuilder`]. This will then be registered with the
 /// [`roadster::service::registry::ServiceRegistry`].
 pub async fn http_service(state: &AppContext) -> RoadsterResult<HttpServiceBuilder<AppContext>> {
-    HttpServiceBuilder::new(Some(BASE), state)
+    HttpServiceBuilder::new(state, Some(BASE))
         .api_router(ApiRouter::new().api_route(
             &build_path(BASE, "/example_b"),
             get_with(example_b::example_b_get, example_b::example_b_get_docs),

--- a/book/examples/service/src/http/mod.rs
+++ b/book/examples/service/src/http/mod.rs
@@ -18,7 +18,7 @@ const BASE: &str = "/api";
 /// Set up the [`HttpServiceBuilder`]. This will then be registered with the
 /// [`roadster::service::registry::ServiceRegistry`].
 pub fn http_service(state: &AppContext) -> HttpServiceBuilder<AppContext> {
-    HttpServiceBuilder::new(Some(BASE), state)
+    HttpServiceBuilder::new(state, Some(BASE))
         // Multiple routers can be registered and they will all be merged together using the
         // `axum::Router::merge` method.
         .router(Router::new().route(&build_path(BASE, "/example_a"), get(example_a)))

--- a/book/examples/service/src/lib.rs
+++ b/book/examples/service/src/lib.rs
@@ -17,7 +17,7 @@ fn build_app() -> App {
         .add_service_provider(move |registry, state| {
             Box::pin(async move {
                 registry
-                    .register_builder(HttpService::builder(Some("/api"), state))
+                    .register_builder(HttpService::builder(state, Some("/api")))
                     .await?;
                 Ok(())
             })

--- a/examples/app-builder/src/lib.rs
+++ b/examples/app-builder/src/lib.rs
@@ -124,7 +124,7 @@ pub fn build_app() -> App {
             Box::pin(async {
                 registry
                     .register_builder(
-                        HttpService::builder(Some(BASE), state).api_router(http::routes(BASE)),
+                        HttpService::builder(state, Some(BASE)).api_router(http::routes(BASE)),
                     )
                     .await?;
                 Ok(())

--- a/examples/diesel/src/lib.rs
+++ b/examples/diesel/src/lib.rs
@@ -41,7 +41,7 @@ pub fn build_app() -> App {
             Box::pin(async {
                 registry
                     .register_builder(
-                        HttpService::builder(Some(BASE), state).api_router(http::routes(BASE)),
+                        HttpService::builder(state, Some(BASE)).api_router(http::routes(BASE)),
                     )
                     .await?;
                 Ok(())

--- a/examples/full/src/app.rs
+++ b/examples/full/src/app.rs
@@ -57,16 +57,16 @@ impl RoadsterApp<AppState> for App {
 
     fn migrators(
         &self,
-        registry: &mut MigratorRegistry<AppState>,
         _state: &AppState,
+        registry: &mut MigratorRegistry<AppState>,
     ) -> Result<(), Self::Error> {
         registry.register_sea_orm_migrator(Migrator)
     }
 
     async fn health_checks(
         &self,
-        registry: &mut HealthCheckRegistry,
         state: &AppState,
+        registry: &mut HealthCheckRegistry,
     ) -> Result<(), Self::Error> {
         registry.register(ExampleHealthCheck::new(state))?;
         Ok(())
@@ -74,8 +74,8 @@ impl RoadsterApp<AppState> for App {
 
     async fn lifecycle_handlers(
         &self,
-        registry: &mut LifecycleHandlerRegistry<Self, AppState>,
         _state: &AppState,
+        registry: &mut LifecycleHandlerRegistry<Self, AppState>,
     ) -> Result<(), Self::Error> {
         registry.register(ExampleLifecycleHandler)?;
         Ok(())
@@ -83,12 +83,12 @@ impl RoadsterApp<AppState> for App {
 
     async fn services(
         &self,
-        registry: &mut ServiceRegistry<AppState>,
         state: &AppState,
+        registry: &mut ServiceRegistry<AppState>,
     ) -> Result<(), Self::Error> {
         registry
             .register_builder(
-                HttpService::builder(Some(BASE), state)
+                HttpService::builder(state, Some(BASE))
                     .api_router(http::routes(BASE))
                     .initializer(
                         AnyInitializer::<AppState, Infallible>::builder()

--- a/examples/leptos-ssr/src/server/mod.rs
+++ b/examples/leptos-ssr/src/server/mod.rs
@@ -42,7 +42,7 @@ pub fn build_app() -> RoadsterApp<AppState> {
 
                 registry
                     .register_builder(
-                        HttpService::builder(Some(BASE), &state).router(leptos_routes(&state)),
+                        HttpService::builder(&state, Some(BASE)).router(leptos_routes(&state)),
                     )
                     .await?;
 

--- a/examples/pg-worker/src/lib.rs
+++ b/examples/pg-worker/src/lib.rs
@@ -27,7 +27,7 @@ pub fn build_app() -> App {
             Box::pin(async {
                 registry
                     .register_builder(
-                        HttpService::builder(Some(BASE), state).api_router(http::routes(BASE)),
+                        HttpService::builder(state, Some(BASE)).api_router(http::routes(BASE)),
                     )
                     .await?;
                 Ok(())

--- a/src/api/http/docs.rs
+++ b/src/api/http/docs.rs
@@ -12,7 +12,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 /// This API is only available when using Aide.
-pub fn routes<S>(parent: &str, state: &S) -> ApiRouter<S>
+pub fn routes<S>(state: &S, parent: &str) -> ApiRouter<S>
 where
     S: 'static + Send + Sync + Clone,
     AppContext: FromRef<S>,

--- a/src/api/http/health.rs
+++ b/src/api/http/health.rs
@@ -23,7 +23,7 @@ use tracing::instrument;
 #[cfg(feature = "open-api")]
 const TAG: &str = "Health";
 
-pub fn routes<S>(parent: &str, state: &S) -> Router<S>
+pub fn routes<S>(state: &S, parent: &str) -> Router<S>
 where
     S: 'static + Send + Sync + Clone,
     AppContext: FromRef<S>,
@@ -38,7 +38,7 @@ where
 }
 
 #[cfg(feature = "open-api")]
-pub fn api_routes<S>(parent: &str, state: &S) -> ApiRouter<S>
+pub fn api_routes<S>(state: &S, parent: &str) -> ApiRouter<S>
 where
     S: 'static + Send + Sync + Clone,
     AppContext: FromRef<S>,

--- a/src/api/http/mod.rs
+++ b/src/api/http/mod.rs
@@ -26,7 +26,7 @@ pub mod ping;
 /// const BASE: &str = "/api";
 ///
 /// async fn http_service(state: &AppContext) -> HttpServiceBuilder<AppContext> {
-///     HttpServiceBuilder::new(Some(BASE), state)
+///     HttpServiceBuilder::new(state, Some(BASE))
 ///         .router(example_a::routes(BASE))
 ///         .router(example_b::routes(BASE))
 /// }
@@ -76,25 +76,25 @@ pub fn build_path(parent: &str, child: &str) -> String {
     path
 }
 
-pub fn default_routes<S>(parent: &str, state: &S) -> Router<S>
+pub fn default_routes<S>(state: &S, parent: &str) -> Router<S>
 where
     S: 'static + Send + Sync + Clone,
     AppContext: FromRef<S>,
 {
     Router::new()
-        .merge(ping::routes(parent, state))
-        .merge(health::routes(parent, state))
+        .merge(ping::routes(state, parent))
+        .merge(health::routes(state, parent))
 }
 
 #[cfg(feature = "open-api")]
-pub fn default_api_routes<S>(parent: &str, state: &S) -> ApiRouter<S>
+pub fn default_api_routes<S>(state: &S, parent: &str) -> ApiRouter<S>
 where
     S: 'static + Send + Sync + Clone,
     AppContext: FromRef<S>,
 {
     ApiRouter::new()
-        .merge(ping::api_routes(parent, state))
-        .merge(health::api_routes(parent, state))
+        .merge(ping::api_routes(state, parent))
+        .merge(health::api_routes(state, parent))
         // The docs route is only available when using Aide
-        .merge(docs::routes(parent, state))
+        .merge(docs::routes(state, parent))
 }

--- a/src/api/http/ping.rs
+++ b/src/api/http/ping.rs
@@ -19,7 +19,7 @@ use tracing::instrument;
 #[cfg(feature = "open-api")]
 const TAG: &str = "Ping";
 
-pub fn routes<S>(parent: &str, state: &S) -> Router<S>
+pub fn routes<S>(state: &S, parent: &str) -> Router<S>
 where
     S: 'static + Send + Sync + Clone,
     AppContext: FromRef<S>,
@@ -34,7 +34,7 @@ where
 }
 
 #[cfg(feature = "open-api")]
-pub fn api_routes<S>(parent: &str, state: &S) -> ApiRouter<S>
+pub fn api_routes<S>(state: &S, parent: &str) -> ApiRouter<S>
 where
     S: 'static + Send + Sync + Clone,
     AppContext: FromRef<S>,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -209,16 +209,16 @@ where
     #[cfg(feature = "db-sql")]
     fn migrators(
         &self,
-        #[allow(unused_variables)] registry: &mut MigratorRegistry<S>,
         #[allow(unused_variables)] state: &S,
+        #[allow(unused_variables)] registry: &mut MigratorRegistry<S>,
     ) -> Result<(), Self::Error> {
         Ok(())
     }
 
     async fn lifecycle_handlers(
         &self,
-        #[allow(unused_variables)] registry: &mut LifecycleHandlerRegistry<Self, S>,
         #[allow(unused_variables)] state: &S,
+        #[allow(unused_variables)] registry: &mut LifecycleHandlerRegistry<Self, S>,
     ) -> Result<(), Self::Error> {
         Ok(())
     }
@@ -226,8 +226,8 @@ where
     /// Provide the [`crate::health::check::HealthCheck`]s to use throughout the app.
     async fn health_checks(
         &self,
-        #[allow(unused_variables)] registry: &mut HealthCheckRegistry,
         #[allow(unused_variables)] state: &S,
+        #[allow(unused_variables)] registry: &mut HealthCheckRegistry,
     ) -> Result<(), Self::Error> {
         Ok(())
     }
@@ -235,8 +235,8 @@ where
     /// Provide the [`crate::service::Service`]s to run in the app.
     async fn services(
         &self,
-        #[allow(unused_variables)] registry: &mut ServiceRegistry<S>,
         #[allow(unused_variables)] state: &S,
+        #[allow(unused_variables)] registry: &mut ServiceRegistry<S>,
     ) -> Result<(), Self::Error> {
         Ok(())
     }
@@ -244,7 +244,7 @@ where
     /// Override to provide a custom shutdown signal. Roadster provides some default shutdown
     /// signals, but it may be desirable to provide a custom signal in order to, e.g., shutdown the
     /// server when a particular API is called.
-    async fn graceful_shutdown_signal(self: Arc<Self>, _state: &S) {
+    async fn graceful_shutdown_signal(self: Arc<Self>, #[allow(unused_variables)] state: &S) {
         let _output: () = future::pending().await;
     }
 }

--- a/src/app/prepare.rs
+++ b/src/app/prepare.rs
@@ -344,24 +344,24 @@ where
     #[cfg(feature = "db-sql")]
     let migrator_registry = {
         let mut migrator_registry = MigratorRegistry::new();
-        app.migrators(&mut migrator_registry, &state)
+        app.migrators(&state, &mut migrator_registry)
             .map_err(|err| crate::error::other::OtherError::Other(Box::new(err)))?;
         migrator_registry
     };
 
     let mut lifecycle_handler_registry = LifecycleHandlerRegistry::new(&state);
-    app.lifecycle_handlers(&mut lifecycle_handler_registry, &state)
+    app.lifecycle_handlers(&state, &mut lifecycle_handler_registry)
         .await
         .map_err(|err| crate::error::other::OtherError::Other(Box::new(err)))?;
 
     let mut health_check_registry = HealthCheckRegistry::new(&context);
-    app.health_checks(&mut health_check_registry, &state)
+    app.health_checks(&state, &mut health_check_registry)
         .await
         .map_err(|err| crate::error::other::OtherError::Other(Box::new(err)))?;
     context.set_health_checks(health_check_registry)?;
 
     let mut service_registry = ServiceRegistry::new(&state);
-    app.services(&mut service_registry, &state)
+    app.services(&state, &mut service_registry)
         .await
         .map_err(|err| crate::error::other::OtherError::Other(Box::new(err)))?;
 

--- a/src/app/roadster_app.rs
+++ b/src/app/roadster_app.rs
@@ -472,8 +472,8 @@ where
 
     async fn health_checks(
         &self,
-        registry: &mut HealthCheckRegistry,
         state: &S,
+        registry: &mut HealthCheckRegistry,
     ) -> RoadsterResult<()> {
         for health_check in self.health_checks.iter() {
             registry.register_arc(health_check.clone())?;
@@ -1339,7 +1339,7 @@ where
     }
 
     #[cfg(feature = "db-sql")]
-    fn migrators(&self, registry: &mut MigratorRegistry<S>, state: &S) -> RoadsterResult<()> {
+    fn migrators(&self, state: &S, registry: &mut MigratorRegistry<S>) -> RoadsterResult<()> {
         #[cfg(feature = "db-sea-orm")]
         {
             let mut sea_orm_migrator = self
@@ -1376,8 +1376,8 @@ where
 
     async fn lifecycle_handlers(
         &self,
-        registry: &mut LifecycleHandlerRegistry<Self, S>,
         state: &S,
+        registry: &mut LifecycleHandlerRegistry<Self, S>,
     ) -> RoadsterResult<()> {
         {
             let mut lifecycle_handlers = self
@@ -1397,13 +1397,13 @@ where
 
     async fn health_checks(
         &self,
-        registry: &mut HealthCheckRegistry,
         state: &S,
+        registry: &mut HealthCheckRegistry,
     ) -> RoadsterResult<()> {
-        self.inner.health_checks(registry, state).await
+        self.inner.health_checks(state, registry).await
     }
 
-    async fn services(&self, registry: &mut ServiceRegistry<S>, state: &S) -> RoadsterResult<()> {
+    async fn services(&self, state: &S, registry: &mut ServiceRegistry<S>) -> RoadsterResult<()> {
         {
             let mut services = self.services.lock().map_err(crate::error::Error::from)?;
             for service in services.drain(..) {

--- a/src/app/run.rs
+++ b/src/app/run.rs
@@ -91,12 +91,12 @@ where
     before_app(&prepared).await?;
 
     let result =
-        crate::service::runner::run(prepared.app, prepared.service_registry, &prepared.state).await;
+        crate::service::runner::run(prepared.app, &prepared.state, prepared.service_registry).await;
     if let Err(err) = result {
         error!("An error occurred in the app: {err}");
     }
 
-    after_app(&prepared.lifecycle_handler_registry, &prepared.state).await?;
+    after_app(&prepared.state, &prepared.lifecycle_handler_registry).await?;
 
     Ok(())
 }
@@ -138,15 +138,15 @@ where
         );
         handler.before_services(prepared_app).await?
     }
-    crate::service::runner::before_run(&prepared_app.service_registry, &prepared_app.state).await?;
+    crate::service::runner::before_run(&prepared_app.state, &prepared_app.service_registry).await?;
 
     Ok(())
 }
 
 /// Run the app's teardown logic.
 pub async fn after_app<A, S>(
-    lifecycle_handler_registry: &LifecycleHandlerRegistry<A, S>,
     state: &S,
+    lifecycle_handler_registry: &LifecycleHandlerRegistry<A, S>,
 ) -> RoadsterResult<()>
 where
     A: 'static + App<S>,

--- a/src/app/test.rs
+++ b/src/app/test.rs
@@ -113,7 +113,7 @@ where
     tracing::debug!("Test complete");
 
     let after_app_result =
-        run::after_app(&prepared.lifecycle_handler_registry, &prepared.state).await;
+        run::after_app(&prepared.state, &prepared.lifecycle_handler_registry).await;
 
     let test_result = if let Some(test_panic) = test_panic {
         match test_panic {

--- a/src/service/http/initializer/any.rs
+++ b/src/service/http/initializer/any.rs
@@ -130,7 +130,7 @@ where
             .unwrap_or_default()
     }
 
-    fn after_router(&self, router: Router, _state: &S) -> Result<Router, Self::Error> {
+    fn after_router(&self, _state: &S, router: Router) -> Result<Router, Self::Error> {
         if let Stage::AfterRouter = self.stage {
             (self.apply)(router, _state)
         } else {
@@ -138,7 +138,7 @@ where
         }
     }
 
-    fn before_middleware(&self, router: Router, _state: &S) -> Result<Router, Self::Error> {
+    fn before_middleware(&self, _state: &S, router: Router) -> Result<Router, Self::Error> {
         if let Stage::BeforeMiddleware = self.stage {
             (self.apply)(router, _state)
         } else {
@@ -146,7 +146,7 @@ where
         }
     }
 
-    fn after_middleware(&self, router: Router, _state: &S) -> Result<Router, Self::Error> {
+    fn after_middleware(&self, _state: &S, router: Router) -> Result<Router, Self::Error> {
         if let Stage::AfterMiddleware = self.stage {
             (self.apply)(router, _state)
         } else {
@@ -154,7 +154,7 @@ where
         }
     }
 
-    fn before_serve(&self, router: Router, _state: &S) -> Result<Router, Self::Error> {
+    fn before_serve(&self, _state: &S, router: Router) -> Result<Router, Self::Error> {
         if let Stage::BeforeServe = self.stage {
             (self.apply)(router, _state)
         } else {

--- a/src/service/http/initializer/mod.rs
+++ b/src/service/http/initializer/mod.rs
@@ -33,32 +33,32 @@ where
 
     fn after_router(
         &self,
-        router: Router,
         #[allow(unused_variables)] state: &S,
+        router: Router,
     ) -> Result<Router, Self::Error> {
         Ok(router)
     }
 
     fn before_middleware(
         &self,
-        router: Router,
         #[allow(unused_variables)] state: &S,
+        router: Router,
     ) -> Result<Router, Self::Error> {
         Ok(router)
     }
 
     fn after_middleware(
         &self,
-        router: Router,
         #[allow(unused_variables)] state: &S,
+        router: Router,
     ) -> Result<Router, Self::Error> {
         Ok(router)
     }
 
     fn before_serve(
         &self,
-        router: Router,
         #[allow(unused_variables)] state: &S,
+        router: Router,
     ) -> Result<Router, Self::Error> {
         Ok(router)
     }

--- a/src/service/http/initializer/normalize_path.rs
+++ b/src/service/http/initializer/normalize_path.rs
@@ -60,7 +60,7 @@ where
     /// is applied after all the routes and normal middleware have been applied.
     ///
     /// See: <https://docs.rs/axum/latest/axum/middleware/index.html#rewriting-request-uri-in-middleware>
-    fn before_serve(&self, router: Router, _state: &S) -> Result<Router, Self::Error> {
+    fn before_serve(&self, _state: &S, router: Router) -> Result<Router, Self::Error> {
         let router = NormalizePathLayer::trim_trailing_slash().layer(router);
         let router = Router::new().fallback_service(router);
         Ok(router)

--- a/src/service/http/middleware/any.rs
+++ b/src/service/http/middleware/any.rs
@@ -122,7 +122,7 @@ where
             .unwrap_or_default()
     }
 
-    fn install(&self, router: Router, state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, state: &S, router: Router) -> Result<Router, Self::Error> {
         (self.apply)(router, state)
     }
 }

--- a/src/service/http/middleware/cache_control.rs
+++ b/src/service/http/middleware/cache_control.rs
@@ -77,7 +77,7 @@ where
             .priority
     }
 
-    fn install(&self, router: Router, state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, state: &S, router: Router) -> Result<Router, Self::Error> {
         let state = state.clone();
         let layer = SetResponseHeaderLayer::if_not_present(
             CACHE_CONTROL,

--- a/src/service/http/middleware/catch_panic.rs
+++ b/src/service/http/middleware/catch_panic.rs
@@ -47,7 +47,7 @@ where
             .priority
     }
 
-    fn install(&self, router: Router, _state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, _state: &S, router: Router) -> Result<Router, Self::Error> {
         let router = router.layer(CatchPanicLayer::new());
 
         Ok(router)

--- a/src/service/http/middleware/compression.rs
+++ b/src/service/http/middleware/compression.rs
@@ -53,7 +53,7 @@ where
             .priority
     }
 
-    fn install(&self, router: Router, _state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, _state: &S, router: Router) -> Result<Router, Self::Error> {
         let router = router.layer(CompressionLayer::new());
 
         Ok(router)
@@ -96,7 +96,7 @@ where
             .priority
     }
 
-    fn install(&self, router: Router, _state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, _state: &S, router: Router) -> Result<Router, Self::Error> {
         let router = router.layer(RequestDecompressionLayer::new());
 
         Ok(router)

--- a/src/service/http/middleware/cors.rs
+++ b/src/service/http/middleware/cors.rs
@@ -178,7 +178,7 @@ where
             .priority
     }
 
-    fn install(&self, router: Router, state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, state: &S, router: Router) -> Result<Router, Self::Error> {
         let context = AppContext::from_ref(state);
         let config = &context.config().service.http.custom.middleware.cors.custom;
         let layer = match config.preset {

--- a/src/service/http/middleware/etag.rs
+++ b/src/service/http/middleware/etag.rs
@@ -51,7 +51,7 @@ where
             .priority
     }
 
-    fn install(&self, router: Router, _state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, _state: &S, router: Router) -> Result<Router, Self::Error> {
         let router = router.layer(middleware::from_fn(etag_middleware));
 
         Ok(router)

--- a/src/service/http/middleware/mod.rs
+++ b/src/service/http/middleware/mod.rs
@@ -53,5 +53,5 @@ where
     /// with priority `-10` will be _installed after_ a middleware with priority `10`, which will
     /// allow the middleware with priority `-10` to _run before_ a middleware with priority `10`.
     fn priority(&self, state: &S) -> i32;
-    fn install(&self, router: Router, state: &S) -> Result<Router, Self::Error>;
+    fn install(&self, state: &S, router: Router) -> Result<Router, Self::Error>;
 }

--- a/src/service/http/middleware/request_id.rs
+++ b/src/service/http/middleware/request_id.rs
@@ -79,7 +79,7 @@ where
             .priority
     }
 
-    fn install(&self, router: Router, state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, state: &S, router: Router) -> Result<Router, Self::Error> {
         let context = AppContext::from_ref(state);
         let header_name = &context
             .config()
@@ -137,7 +137,7 @@ where
             .priority
     }
 
-    fn install(&self, router: Router, state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, state: &S, router: Router) -> Result<Router, Self::Error> {
         let context = AppContext::from_ref(state);
         let header_name = &context
             .config()

--- a/src/service/http/middleware/sensitive_headers.rs
+++ b/src/service/http/middleware/sensitive_headers.rs
@@ -97,7 +97,7 @@ where
             .common
             .priority
     }
-    fn install(&self, router: Router, state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, state: &S, router: Router) -> Result<Router, Self::Error> {
         let headers = AppContext::from_ref(state)
             .config()
             .service
@@ -151,7 +151,7 @@ where
             .priority
     }
 
-    fn install(&self, router: Router, state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, state: &S, router: Router) -> Result<Router, Self::Error> {
         let headers = AppContext::from_ref(state)
             .config()
             .service

--- a/src/service/http/middleware/size_limit.rs
+++ b/src/service/http/middleware/size_limit.rs
@@ -61,7 +61,7 @@ where
             .priority
     }
 
-    fn install(&self, router: Router, state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, state: &S, router: Router) -> Result<Router, Self::Error> {
         let limit = &AppContext::from_ref(state)
             .config()
             .service

--- a/src/service/http/middleware/timeout.rs
+++ b/src/service/http/middleware/timeout.rs
@@ -61,7 +61,7 @@ where
             .priority
     }
 
-    fn install(&self, router: Router, state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, state: &S, router: Router) -> Result<Router, Self::Error> {
         let context = AppContext::from_ref(state);
         let timeout = &context
             .config()

--- a/src/service/http/middleware/tracing/mod.rs
+++ b/src/service/http/middleware/tracing/mod.rs
@@ -84,7 +84,7 @@ where
             .priority
     }
 
-    fn install(&self, router: Router, state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, state: &S, router: Router) -> Result<Router, Self::Error> {
         let context = AppContext::from_ref(state);
         let middleware_config = &context.config().service.http.custom.middleware;
         let request_id_header_name = &middleware_config.set_request_id.custom.common.header_name;

--- a/src/service/http/middleware/tracing/req_res_logging.rs
+++ b/src/service/http/middleware/tracing/req_res_logging.rs
@@ -93,7 +93,7 @@ where
             .priority
     }
 
-    fn install(&self, router: Router, state: &S) -> Result<Router, Self::Error> {
+    fn install(&self, state: &S, router: Router) -> Result<Router, Self::Error> {
         let max_len = AppContext::from_ref(state)
             .config()
             .service

--- a/src/service/http/service.rs
+++ b/src/service/http/service.rs
@@ -72,12 +72,12 @@ where
 
 impl HttpService {
     /// Create a new [HttpServiceBuilder].
-    pub fn builder<S>(path_root: Option<&str>, state: &S) -> HttpServiceBuilder<S>
+    pub fn builder<S>(state: &S, path_root: Option<&str>) -> HttpServiceBuilder<S>
     where
         S: 'static + Send + Sync + Clone,
         AppContext: FromRef<S>,
     {
-        HttpServiceBuilder::new(path_root, state)
+        HttpServiceBuilder::new(state, path_root)
     }
 
     pub fn router(&self) -> &Router {

--- a/src/service/registry.rs
+++ b/src/service/registry.rs
@@ -150,7 +150,7 @@ let app: App = RoadsterApp::builder()
     .state_provider(|state| Ok(state))
     .add_service_provider(|registry, state| Box::pin(async  {
         registry.register_builder(
-            HttpService::builder(Some("/api"), state)
+            HttpService::builder(state, Some("/api"))
         ).await?;
         Ok(())
     }))

--- a/src/service/runner.rs
+++ b/src/service/runner.rs
@@ -40,8 +40,8 @@ pub(crate) async fn health_checks(
 
 #[instrument(skip_all)]
 pub(crate) async fn before_run<S>(
-    service_registry: &ServiceRegistry<S>,
     state: &S,
+    service_registry: &ServiceRegistry<S>,
 ) -> RoadsterResult<()>
 where
     S: 'static + Send + Sync + Clone,
@@ -58,8 +58,8 @@ where
 
 pub(crate) async fn run<A, S>(
     app: A,
-    service_registry: ServiceRegistry<S>,
     state: &S,
+    service_registry: ServiceRegistry<S>,
 ) -> RoadsterResult<()>
 where
     S: 'static + Send + Sync + Clone,


### PR DESCRIPTION
Some methods use the app state as the first parameter and others do not. This PR refactors all methods to ensure that any method that takes app state as a parameter has it as the first parameter. The exception is the few methods that take an instance of the `App` trait -- those take the `App` trait as the first parameter.

Closes https://github.com/roadster-rs/roadster/issues/934