### PR TITLE
fix: Adjust res compression to enable logging before compression

### DIFF
--- a/src/config/service/http/config/default.toml
+++ b/src/config/service/http/config/default.toml
@@ -28,7 +28,7 @@ priority = -9980
 priority = 0
 
 [service.http.middleware.response-compression]
-priority = 0
+priority = 9900
 min-size-bytes = 32
 level = "default"
 not-for-content-types = []

--- a/src/service/http/middleware/compression.rs
+++ b/src/service/http/middleware/compression.rs
@@ -270,7 +270,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case(None, 0)]
+    #[case(None, 9900)]
     #[case(Some(1234), 1234)]
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn response_compression_priority(


### PR DESCRIPTION
Adjust the priority of the
`service.http.middleware.response-compression` middleware to be near the end of the middleware chain. This allows the other middleware in the chain to see the original response payload; for example, the response logging middleware.

Closes https://github.com/roadster-rs/roadster/issues/954