### PR TITLE
fix: Adjust res compression to enable logging before compression (2)

### DIFF
--- a/src/config/service/http/config/default.toml
+++ b/src/config/service/http/config/default.toml
@@ -28,7 +28,7 @@ priority = -9980
 priority = 0
 
 [service.http.middleware.response-compression]
-priority = 9900
+priority = 0
 min-size-bytes = 32
 level = "default"
 not-for-content-types = []
@@ -67,7 +67,7 @@ limit = "5 MB"
 priority = -9950
 
 [service.http.middleware.request-response-logging]
-priority = 0
+priority = 9900
 max-len = 1000
 
 # Initializers

--- a/src/service/http/middleware/compression.rs
+++ b/src/service/http/middleware/compression.rs
@@ -270,7 +270,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case(None, 9900)]
+    #[case(None, 0)]
     #[case(Some(1234), 1234)]
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn response_compression_priority(

--- a/src/service/http/middleware/tracing/req_res_logging.rs
+++ b/src/service/http/middleware/tracing/req_res_logging.rs
@@ -303,7 +303,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case(None, 0)]
+    #[case(None, 9900)]
     #[case(Some(1234), 1234)]
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn priority(#[case] override_priority: Option<i32>, #[case] expected_priority: i32) {


### PR DESCRIPTION
Second attempt to adjust the priority of the middleware to allow logging responses before they are compressed. Instead of the previous PR (#955) which changed the `service.http.middleware.response-compression` middleware priority, this PR reverts the previous change and instead updates the `service.http.middleware.request-response-logging` middleware priority. The reason is that when responses go through the middleware, they go in reverse order of when handling a request, so the `request-response-logging` middleware needs to be installed after the `response-compression` middleware so they run in the correct order when handling the response