### PR TITLE
feat: Allow retrying worker job without returning an error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5414,9 +5414,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
  "log",
  "num",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -1557,9 +1557,9 @@ checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "diesel"
-version = "2.3.3"
+version = "2.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e7624a3bb9fffd82fff016be9a7f163d20e5a89eb8d28f9daaa6b30fff37500"
+checksum = "78df0e4e8c596662edb07fbfbb7f23769cca35049827df5f909084d956b6aeaf"
 dependencies = [
  "bigdecimal",
  "bitflags",
@@ -1877,7 +1877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1930,7 +1930,7 @@ checksum = "f2b0902eb36fbab51c14eda1c186bda119fcff91e5e4e7fc2dd2077298197ce8"
 dependencies = [
  "deunicode",
  "either",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -1952,7 +1952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0e9414a6ae93ef993ce40a1e02944f13d4508e2bf6f1ced1580ce6910f08253"
 dependencies = [
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.9.4",
  "web-time",
 ]
 
@@ -2912,7 +2912,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3058,7 +3058,7 @@ dependencies = [
  "oco_ref",
  "or_poisoned",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reactive_graph",
  "rustc-hash",
  "rustc_version",
@@ -3607,7 +3607,7 @@ dependencies = [
  "mysql_common",
  "pem",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "socket2 0.5.10",
@@ -3686,7 +3686,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3938,7 +3938,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -4362,7 +4362,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha2",
  "stringprep",
 ]
@@ -4403,7 +4403,7 @@ dependencies = [
  "clap",
  "insta",
  "itertools 0.14.0",
- "rand 0.9.2",
+ "rand 0.9.4",
  "roadster",
  "rstest",
  "serde",
@@ -4676,7 +4676,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4699,7 +4699,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4775,9 +4775,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -5161,7 +5161,7 @@ dependencies = [
  "opentelemetry_sdk",
  "pgmq",
  "r2d2",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "reqwest 0.13.1",
  "roadster",
@@ -5344,7 +5344,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5403,7 +5403,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6707,7 +6707,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6716,7 +6716,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2111ef44dae28680ae9752bb89409e7310ca33a8c621ebe7b106cf5c928b3ac0"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6958,7 +6958,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.2",
+ "rand 0.9.4",
  "socket2 0.6.1",
  "tokio",
  "tokio-util",
@@ -7395,7 +7395,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.17",
  "utf-8",
@@ -7848,7 +7848,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,7 +3010,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -3724,7 +3724,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -4764,9 +4764,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -5300,7 +5300,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -5444,7 +5444,7 @@ dependencies = [
  "gethostname",
  "hex",
  "num_cpus",
- "rand 0.8.5",
+ "rand 0.8.6",
  "redis",
  "serde",
  "serde_json",
@@ -6398,7 +6398,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "rust_decimal",
  "serde",
@@ -6442,7 +6442,7 @@ dependencies = [
  "memchr",
  "num-bigint",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rust_decimal",
  "serde",
  "serde_json",

--- a/deny.toml
+++ b/deny.toml
@@ -71,7 +71,7 @@ feature-depth = 1
 # output a note when they are encountered.
 ignore = [
     { id = "RUSTSEC-2023-0071", reason = "Transitive dependency; need other dependencies to resolve first." },
-    { id = "RUSTSEC-2024-0436", reason = "Transitive dependency; need other dependencies to resolve first." },
+    { id = "RUSTSEC-2026-0002", reason = "Transitive dependency; need other dependencies to resolve first." },
     { id = "RUSTSEC-2026-0044", reason = "Transitive dependency; need other dependencies to resolve first." },
     { id = "RUSTSEC-2026-0045", reason = "Transitive dependency; need other dependencies to resolve first." },
     { id = "RUSTSEC-2026-0046", reason = "Transitive dependency; need other dependencies to resolve first." },

--- a/deny.toml
+++ b/deny.toml
@@ -72,7 +72,6 @@ feature-depth = 1
 ignore = [
     { id = "RUSTSEC-2023-0071", reason = "Transitive dependency; need other dependencies to resolve first." },
     { id = "RUSTSEC-2024-0436", reason = "Transitive dependency; need other dependencies to resolve first." },
-    { id = "RUSTSEC-2026-0002", reason = "Transitive dependency; need other dependencies to resolve first." },
     { id = "RUSTSEC-2026-0044", reason = "Transitive dependency; need other dependencies to resolve first." },
     { id = "RUSTSEC-2026-0045", reason = "Transitive dependency; need other dependencies to resolve first." },
     { id = "RUSTSEC-2026-0046", reason = "Transitive dependency; need other dependencies to resolve first." },

--- a/src/worker/backend/pg/processor/mod.rs
+++ b/src/worker/backend/pg/processor/mod.rs
@@ -11,7 +11,7 @@ use crate::worker::backend::pg::periodic_job::PeriodicJob;
 use crate::worker::backend::pg::{failure_action, retry_delay, success_action};
 use crate::worker::backend::shared_queues;
 use crate::worker::config::CompletedAction;
-use crate::worker::job::{Job, JobMetadata};
+use crate::worker::job::{Job, JobMetadata, JobState};
 use axum_core::extract::FromRef;
 use builder::PgProcessorBuilder;
 use chrono::{DateTime, TimeDelta, Utc};
@@ -479,37 +479,68 @@ where
                     .handle(&self.inner.state, &job.metadata, job.args)
                     .await;
 
-                if let Err(err) = result {
-                    error!(
-                        job.id = %job.metadata.id,
-                        job.msg_id = msg.msg_id,
-                        job.read_count = msg.read_ct,
-                        worker.queue.name = queue.name,
-                        worker.name = job.metadata.worker_name,
-                        "An error occurred while handling a job: {err}"
-                    );
-                    self.retry(
-                        pgmq,
-                        &queue,
-                        Some(&job.metadata),
-                        msg.msg_id,
-                        msg.read_ct,
-                        context.config(),
-                        Some(worker),
-                    )
-                    .await;
-                } else {
-                    let action =
-                        success_action(context.config(), worker.inner.worker_config.pg.as_ref());
-                    self.job_completed(
-                        pgmq,
-                        &queue,
-                        Some(&job.metadata),
-                        msg.msg_id,
-                        msg.read_ct,
-                        action,
-                    )
-                    .await;
+                match result {
+                    Ok(job_state) => {
+                        debug!(
+                            job.id = %job.metadata.id,
+                            job.msg_id = msg.msg_id,
+                            job.read_count = msg.read_ct,
+                            job.state = job_state.to_string(),
+                            worker.queue.name = queue.name,
+                            worker.name = job.metadata.worker_name,
+                            "Job run completed"
+                        );
+
+                        match job_state {
+                            JobState::Done => {
+                                let action = success_action(
+                                    context.config(),
+                                    worker.inner.worker_config.pg.as_ref(),
+                                );
+                                self.job_completed(
+                                    pgmq,
+                                    &queue,
+                                    Some(&job.metadata),
+                                    msg.msg_id,
+                                    msg.read_ct,
+                                    action,
+                                )
+                                .await;
+                            }
+                            JobState::Retry => {
+                                self.retry(
+                                    pgmq,
+                                    &queue,
+                                    Some(&job.metadata),
+                                    msg.msg_id,
+                                    msg.read_ct,
+                                    context.config(),
+                                    Some(worker),
+                                )
+                                .await;
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        error!(
+                            job.id = %job.metadata.id,
+                            job.msg_id = msg.msg_id,
+                            job.read_count = msg.read_ct,
+                            worker.queue.name = queue.name,
+                            worker.name = job.metadata.worker_name,
+                            "An error occurred while handling a job: {err}"
+                        );
+                        self.retry(
+                            pgmq,
+                            &queue,
+                            Some(&job.metadata),
+                            msg.msg_id,
+                            msg.read_ct,
+                            context.config(),
+                            Some(worker),
+                        )
+                        .await;
+                    }
                 }
 
                 #[cfg(feature = "bench")]

--- a/src/worker/backend/sidekiq/roadster_worker.rs
+++ b/src/worker/backend/sidekiq/roadster_worker.rs
@@ -1,5 +1,5 @@
 use crate::app::context::AppContext;
-use crate::worker::job::Job;
+use crate::worker::job::{Job, JobState};
 use crate::worker::{Worker, WorkerWrapper};
 use async_trait::async_trait;
 use axum_core::extract::FromRef;
@@ -132,10 +132,21 @@ where
     }
 
     async fn perform(&self, job: Job) -> sidekiq::Result<()> {
-        self.inner
+        let job_state = self
+            .inner
             .handle(&self.state, &job.metadata, job.args)
             .await
             .map_err(|err| sidekiq::Error::Any(Box::new(err)))?;
+
+        match job_state {
+            JobState::Done => {}
+            JobState::Retry => {
+                return Err(sidekiq::Error::Message(format!(
+                    "Job successful with state: `{job_state}`"
+                )));
+            }
+        }
+
         Ok(())
     }
 }

--- a/src/worker/job.rs
+++ b/src/worker/job.rs
@@ -46,6 +46,21 @@ impl From<u64> for JobId {
     }
 }
 
+#[derive(
+    Debug, Copy, Clone, derive_more::Display, serde::Serialize, serde::Deserialize, Eq, PartialEq,
+)]
+#[non_exhaustive]
+pub enum JobState {
+    Done,
+    Retry,
+}
+
+impl From<()> for JobState {
+    fn from(_value: ()) -> Self {
+        Self::Done
+    }
+}
+
 // Todo: Not sure if this should be public yet.
 #[cfg(any(feature = "worker-sidekiq", feature = "worker-pg"))]
 pub(crate) fn periodic_hash<H: std::hash::Hasher>(

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -12,6 +12,7 @@ use crate::worker::config::{EnqueueConfig, WorkerConfig};
 use crate::worker::enqueue::Enqueuer;
 #[cfg(any(feature = "worker-sidekiq", feature = "worker-pg"))]
 use crate::worker::job::JobMetadata;
+use crate::worker::job::JobState;
 use async_trait::async_trait;
 use axum_core::extract::FromRef;
 use cron::Schedule;
@@ -127,7 +128,7 @@ where
         Ok(())
     }
 
-    async fn handle(&self, state: &S, args: Args) -> Result<(), Self::Error>;
+    async fn handle(&self, state: &S, args: Args) -> Result<impl Into<JobState>, Self::Error>;
 
     /// This is a "private" API that's only intended for usage in Roadster's internal benchmarking suite.
     /// This method does not follow any semver guarantees.
@@ -144,7 +145,7 @@ type WorkerFn<S> = Box<
             &'a S,
             serde_json::Value,
         ) -> std::pin::Pin<
-            Box<dyn 'a + Send + Future<Output = crate::error::RoadsterResult<()>>>,
+            Box<dyn 'a + Send + Future<Output = crate::error::RoadsterResult<JobState>>>,
         >,
 >;
 
@@ -219,7 +220,7 @@ where
                             .map_err(crate::error::worker::DequeueError::Serde)?;
 
                         match worker.clone().handle(state, args).await {
-                            Ok(_) => Ok(()),
+                            Ok(job_state) => Ok(job_state.into()),
                             Err(err) => Err(crate::error::Error::from(
                                 crate::error::worker::WorkerError::Handle(W::name(), Box::new(err)),
                             )),
@@ -242,7 +243,7 @@ where
         state: &S,
         job_metadata: &JobMetadata,
         args: serde_json::Value,
-    ) -> crate::error::RoadsterResult<()> {
+    ) -> crate::error::RoadsterResult<JobState> {
         use futures::FutureExt;
         use tracing::Instrument;
 


### PR DESCRIPTION
Problem
-------
Sometimes, we might want to retry a job at a later time due to a known condition instead of an error. For example, maybe the db entity we want to modify is locked — instead of waiting to acquire the lock directly in the worker, we could retry in order to allow another job to run while we’re waiting for the lock.

Solution
--------
Add a new `JobState` enum and update the `Worker::handle` method to return `impl Into<JobState>`. Also, add `impl From<()> JobState` to allow consumers to continue returning `Result<(), ...>` instead of needing to update all implementations to return `Result<JobState, ...>` explicitly.

Update the PG processor to retry when the job is successful but returns `JobState::Retry`. Update the `RoadsterWorker` (wrapper for `rusty-sidekiq`) to return an error when the job returns `JobState::Retry` to cause `rusty-sidekiq` to retry the job.

Closes https://github.com/roadster-rs/roadster/issues/966